### PR TITLE
Unified ontology explorer and property support

### DIFF
--- a/folio_api/api.py
+++ b/folio_api/api.py
@@ -23,6 +23,7 @@ import folio_api.routes.root
 import folio_api.routes.search
 import folio_api.routes.taxonomy
 import folio_api.routes.properties
+import folio_api.routes.explore
 from folio_api.api_config import load_config
 
 
@@ -237,6 +238,7 @@ def get_app() -> FastAPI:
     app_instance.include_router(folio_api.routes.search.router)
     app_instance.include_router(folio_api.routes.taxonomy.router)
     app_instance.include_router(folio_api.routes.properties.router)
+    app_instance.include_router(folio_api.routes.explore.router)
 
     return app_instance
 

--- a/folio_api/api.py
+++ b/folio_api/api.py
@@ -3,6 +3,7 @@
 # imports
 import logging
 import os
+from collections import defaultdict
 from contextlib import asynccontextmanager
 from typing import Any, Dict
 from pathlib import Path
@@ -21,6 +22,7 @@ import folio_api.routes.info
 import folio_api.routes.root
 import folio_api.routes.search
 import folio_api.routes.taxonomy
+import folio_api.routes.properties
 from folio_api.api_config import load_config
 
 
@@ -64,6 +66,13 @@ async def lifespan_handler(app_instance: FastAPI):
         app_instance.state.config["folio"],
         app_instance.state.config["llm"],
     )
+
+    # Build reverse index for property children lookups
+    property_children = defaultdict(list)
+    for prop in app_instance.state.folio.object_properties:
+        for parent_iri in prop.sub_property_of:
+            property_children[parent_iri].append(prop)
+    app_instance.state.property_children = dict(property_children)
 
     # log it
     app_instance.state.logger.info(
@@ -162,6 +171,10 @@ def get_app() -> FastAPI:
                 "name": "taxonomy",
                 "description": "Endpoints for exploring ontology hierarchies and class categories",
             },
+            {
+                "name": "properties",
+                "description": "Endpoints for browsing and exploring OWL object properties",
+            },
         ],
         docs_url="/docs",
         terms_of_service=api_config["terms_of_service"],
@@ -212,11 +225,18 @@ def get_app() -> FastAPI:
     # Store templates instance in app state
     app_instance.state.templates = Jinja2Templates(directory=templates_dir)
 
+    # INTERIM FIX: Register strip_folio_prefix Jinja2 filter for human-readable property labels.
+    # Remove this once https://github.com/alea-institute/FOLIO/pull/5 is merged and
+    # folio-python is updated with human-readable rdfs:label values.
+    from folio_api.rendering import strip_folio_prefix
+    app_instance.state.templates.env.filters["strip_folio_prefix"] = strip_folio_prefix
+
     # Attach the routes
     app_instance.include_router(folio_api.routes.info.router)
     app_instance.include_router(folio_api.routes.root.router)
     app_instance.include_router(folio_api.routes.search.router)
     app_instance.include_router(folio_api.routes.taxonomy.router)
+    app_instance.include_router(folio_api.routes.properties.router)
 
     return app_instance
 

--- a/folio_api/models/__init__.py
+++ b/folio_api/models/__init__.py
@@ -6,6 +6,6 @@ schemas in the FOLIO API.
 """
 
 from folio_api.models.health import HealthResponse, FOLIOGraphInfo
-from folio_api.models.owl import OWLClassList, OWLSearchResults
+from folio_api.models.owl import OWLClassList, OWLObjectPropertyList, OWLSearchResults
 
-__all__ = ["HealthResponse", "FOLIOGraphInfo", "OWLClassList", "OWLSearchResults"]
+__all__ = ["HealthResponse", "FOLIOGraphInfo", "OWLClassList", "OWLObjectPropertyList", "OWLSearchResults"]

--- a/folio_api/models/health.py
+++ b/folio_api/models/health.py
@@ -48,6 +48,12 @@ class FOLIOGraphInfo(BaseModel):
         description="Total number of ontology classes in the graph", example=1025, gt=0
     )
 
+    num_properties: int = Field(
+        description="Total number of OWL object properties in the graph",
+        example=175,
+        ge=0,
+    )
+
     title: str = Field(
         description="Title of the FOLIO ontology", example="FOLIO Ontology"
     )

--- a/folio_api/models/owl.py
+++ b/folio_api/models/owl.py
@@ -1,8 +1,8 @@
 """
-Models for FOLIO ontology classes and search results.
+Models for FOLIO ontology classes, object properties, and search results.
 
 These models define the response schemas for the API endpoints that return
-FOLIO ontology classes and search results.
+FOLIO ontology classes, object properties, and search results.
 """
 
 # Standard library imports
@@ -10,7 +10,7 @@ from typing import List, Tuple, Union
 
 # Third-party imports
 from pydantic import BaseModel, Field
-from folio import OWLClass
+from folio import OWLClass, OWLObjectProperty
 
 
 class OWLClassList(BaseModel):
@@ -48,6 +48,30 @@ class OWLClassList(BaseModel):
                 "iri": "R8pNPutX0TN6DlEqkyZuxSw",
                 "label": "Lessor",
                 "definition": "A party that grants a right to use something in return for payment.",
+            }
+        ],
+    )
+    properties: List[OWLObjectProperty] = Field(
+        default_factory=list,
+        description="List of OWLObjectProperty objects matching the search",
+    )
+
+
+class OWLObjectPropertyList(BaseModel):
+    """
+    A collection of OWLObjectProperty objects from the FOLIO ontology.
+
+    Attributes:
+        properties: A list of OWLObjectProperty objects representing FOLIO ontology object properties
+    """
+
+    properties: List[OWLObjectProperty] = Field(
+        description="List of OWLObjectProperty objects from the FOLIO ontology",
+        example=[
+            {
+                "iri": "R6qohvM786wjw0MNQJg9Dq",
+                "label": "drafted",
+                "definition": "A relationship indicating that something was drafted.",
             }
         ],
     )

--- a/folio_api/rendering/__init__.py
+++ b/folio_api/rendering/__init__.py
@@ -9,12 +9,20 @@ from folio_api.rendering.html_formatter import (
     format_label,
     format_description,
     get_node_neighbors,
+    format_property_label,
+    format_property_description,
+    get_property_neighbors,
     render_tailwind_html,
+    strip_folio_prefix,
 )
 
 __all__ = [
     "format_label",
     "format_description",
     "get_node_neighbors",
+    "format_property_label",
+    "format_property_description",
+    "get_property_neighbors",
     "render_tailwind_html",
+    "strip_folio_prefix",
 ]

--- a/folio_api/rendering/html_formatter.py
+++ b/folio_api/rendering/html_formatter.py
@@ -8,7 +8,20 @@ import json
 from typing import Dict, List, Tuple
 
 # packages
-from folio import FOLIO, OWLClass
+from folio import FOLIO, OWLClass, OWLObjectProperty
+
+
+def strip_folio_prefix(label: str) -> str:
+    """Strip the 'folio:' prefix from property labels for human-readable display.
+
+    INTERIM FIX: Remove this function once https://github.com/alea-institute/FOLIO/pull/5
+    is merged and folio-python is updated with human-readable rdfs:label values.
+    At that point, also remove the Jinja2 filter registration in api.py and all
+    template usages of |strip_folio_prefix.
+    """
+    if label and label.startswith("folio:"):
+        return label[6:]
+    return label or ""
 
 
 def format_label(owl_class: OWLClass) -> str:
@@ -223,6 +236,171 @@ def get_node_neighbors(
                     "target": owl_class.is_defined_by,
                     "type": "is_defined_by",
                 }
+            )
+
+    return list(nodes.values()), edges
+
+
+def format_property_label(prop: OWLObjectProperty) -> str:
+    """
+    Format the label of an object property for display in HTML.
+
+    Args:
+        prop (OWLObjectProperty): FOLIO OWLObjectProperty object
+
+    Returns:
+        str: Formatted label
+    """
+    # INTERIM: strip_folio_prefix calls can be removed once FOLIO PR #5 is merged
+    if prop.preferred_label:
+        return strip_folio_prefix(prop.preferred_label)
+    elif prop.label:
+        return strip_folio_prefix(prop.label)
+    elif prop.alternative_labels:
+        return strip_folio_prefix(prop.alternative_labels[0])
+    else:
+        return prop.iri
+
+
+def format_property_description(prop: OWLObjectProperty) -> str:
+    """
+    Format the description of an object property for display in HTML.
+
+    Args:
+        prop (OWLObjectProperty): FOLIO OWLObjectProperty object
+
+    Returns:
+        str: Formatted description
+    """
+    # INTERIM: strip_folio_prefix calls can be removed once FOLIO PR #5 is merged
+    label = strip_folio_prefix(prop.label) if prop.label else None
+    if label and prop.definition:
+        return label + " - " + prop.definition
+    elif label:
+        return label
+    elif prop.definition:
+        return prop.definition
+    else:
+        return "No description available."
+
+
+def get_property_neighbors(
+    prop: OWLObjectProperty,
+    folio_graph: FOLIO,
+    property_children: Dict[str, List[OWLObjectProperty]] = None,
+) -> Tuple[List[Dict], List[Dict]]:
+    """
+    Get the neighbors of an object property for Cytoscape visualization.
+
+    Args:
+        prop (OWLObjectProperty): FOLIO OWLObjectProperty object
+        folio_graph (FOLIO): FOLIO graph object
+        property_children (Dict): Pre-computed reverse index of parent->children
+
+    Returns:
+        Tuple[List[Dict], List[Dict]]: Tuple with lists of nodes and edges
+    """
+    nodes = {}
+    edges = []
+
+    # Add self
+    # INTERIM: strip_folio_prefix calls in this function can be removed once FOLIO PR #5 is merged
+    nodes[prop.iri] = {
+        "id": prop.iri,
+        "label": strip_folio_prefix(prop.label or prop.iri),
+        "description": format_property_description(prop),
+        "color": "#000000",
+        "relationship": "self",
+        "entity_type": "property",
+    }
+
+    # Add parent properties (via sub_property_of)
+    for parent_iri in prop.sub_property_of:
+        if parent_iri == "http://www.w3.org/2002/07/owl#topObjectProperty":
+            continue
+        parent = folio_graph.get_property(parent_iri)
+        if parent:
+            nodes[parent_iri] = {
+                "id": parent_iri,
+                "label": strip_folio_prefix(parent.label or parent_iri.split("/")[-1]),
+                "description": format_property_description(parent),
+                "color": "#000000",
+                "relationship": "sub_property_of",
+                "entity_type": "property",
+            }
+            edges.append(
+                {"source": parent_iri, "target": prop.iri, "type": "sub_property_of"}
+            )
+
+    # Add child properties (reverse lookup)
+    children = []
+    if property_children is not None:
+        children = property_children.get(prop.iri, [])
+    else:
+        # Fallback: scan all properties
+        for p in folio_graph.object_properties:
+            if prop.iri in p.sub_property_of:
+                children.append(p)
+
+    for child in children:
+        nodes[child.iri] = {
+            "id": child.iri,
+            "label": strip_folio_prefix(child.label or child.iri.split("/")[-1]),
+            "description": format_property_description(child),
+            "color": "#000000",
+            "relationship": "child_property",
+            "entity_type": "property",
+        }
+        edges.append(
+            {"source": prop.iri, "target": child.iri, "type": "child_property"}
+        )
+
+    # Add domain classes
+    for domain_iri in prop.domain:
+        domain_class = folio_graph[domain_iri]
+        if domain_class:
+            nodes[domain_iri] = {
+                "id": domain_iri,
+                "label": domain_class.label or domain_iri.split("/")[-1],
+                "description": format_description(domain_class),
+                "color": "#0D9488",
+                "relationship": "domain",
+                "entity_type": "class",
+            }
+            edges.append(
+                {"source": domain_iri, "target": prop.iri, "type": "domain"}
+            )
+
+    # Add range classes
+    for range_iri in prop.range:
+        range_class = folio_graph[range_iri]
+        if range_class:
+            nodes[range_iri] = {
+                "id": range_iri,
+                "label": range_class.label or range_iri.split("/")[-1],
+                "description": format_description(range_class),
+                "color": "#EA580C",
+                "relationship": "range",
+                "entity_type": "class",
+            }
+            edges.append(
+                {"source": prop.iri, "target": range_iri, "type": "range"}
+            )
+
+    # Add inverse property
+    if prop.inverse_of:
+        inverse = folio_graph.get_property(prop.inverse_of)
+        if inverse:
+            nodes[prop.inverse_of] = {
+                "id": prop.inverse_of,
+                "label": strip_folio_prefix(inverse.label or prop.inverse_of.split("/")[-1]),
+                "description": format_property_description(inverse),
+                "color": "#7C3AED",
+                "relationship": "inverse_of",
+                "entity_type": "property",
+            }
+            edges.append(
+                {"source": prop.iri, "target": prop.inverse_of, "type": "inverse_of"}
             )
 
     return list(nodes.values()), edges

--- a/folio_api/routes/explore.py
+++ b/folio_api/routes/explore.py
@@ -1,0 +1,36 @@
+"""
+Unified explore routes for the FOLIO API — combined class + property tree view.
+"""
+
+# imports
+from pathlib import Path
+
+# packages
+from fastapi import APIRouter, Request
+from starlette.responses import Response
+
+# API router
+router = APIRouter(prefix="/explore", tags=["explore"])
+
+
+@router.get(
+    "/tree",
+    tags=["explore"],
+    response_model=None,
+    summary="Unified Ontology Explorer",
+    description="Explore both FOLIO classes and properties in a single interactive tree view",
+    include_in_schema=False,
+)
+async def explore_tree(request: Request) -> Response:
+    """Unified tree explorer combining classes (nouns) and properties (verbs)."""
+    typeahead_js_path = Path(__file__).parent.parent / "static" / "js" / "typeahead_search.js"
+    typeahead_js_source = typeahead_js_path.read_text(encoding="utf-8")
+
+    return request.app.state.templates.TemplateResponse(
+        "explore/tree.html",
+        {
+            "request": request,
+            "typeahead_js_source": typeahead_js_source,
+            "config": request.app.state.config,
+        },
+    )

--- a/folio_api/routes/info.py
+++ b/folio_api/routes/info.py
@@ -93,6 +93,7 @@ async def health(request: Request) -> HealthResponse:
         status="healthy",
         folio_graph=FOLIOGraphInfo(
             num_classes=len(folio),
+            num_properties=len(folio.object_properties),
             title=folio.title,
             description=folio.description,
             source_type=folio.source_type,

--- a/folio_api/routes/properties.py
+++ b/folio_api/routes/properties.py
@@ -19,6 +19,13 @@ router = APIRouter(prefix="/properties", tags=["properties"])
 # The OWL top-level property IRI
 OWL_TOP_OBJECT_PROPERTY = "http://www.w3.org/2002/07/owl#topObjectProperty"
 
+# Root properties to hide from the tree
+HIDDEN_ROOT_PROPERTY_IRIS = {
+    "https://folio.openlegalstandard.org/RBD1G5FjdaXj6UM26EWBxJc",  # utbms:activities
+    "https://folio.openlegalstandard.org/RDc1B2GDj6ckfXBkRRSJXfH",  # TR:SALI
+    "https://folio.openlegalstandard.org/RDNZZOyU2yb5Q9xbxIWXd62",  # ZZZ:DEPRECATED PROPERTIES
+}
+
 
 def _find_property(folio: FOLIO, iri: str) -> OWLObjectProperty | None:
     """4-step IRI resolution for properties (mirrors class resolution pattern)."""
@@ -61,7 +68,7 @@ def _is_root_property(prop: OWLObjectProperty) -> bool:
 
 def _get_root_properties(folio: FOLIO) -> list[OWLObjectProperty]:
     """Get all root-level object properties."""
-    roots = [p for p in folio.object_properties if _is_root_property(p)]
+    roots = [p for p in folio.object_properties if _is_root_property(p) and p.iri not in HIDDEN_ROOT_PROPERTY_IRIS]
     roots.sort(key=lambda p: (p.label or p.iri).lower())
     return roots
 

--- a/folio_api/routes/properties.py
+++ b/folio_api/routes/properties.py
@@ -8,7 +8,7 @@ from pathlib import Path
 # packages
 from fastapi import APIRouter, Request, status
 from folio import FOLIO, OWLObjectProperty
-from starlette.responses import Response, JSONResponse
+from starlette.responses import Response, JSONResponse, RedirectResponse
 
 # project
 from folio_api.rendering import get_property_neighbors, strip_folio_prefix
@@ -136,18 +136,12 @@ async def browse_properties(request: Request) -> Response:
     status_code=status.HTTP_200_OK,
 )
 async def explore_property_tree(request: Request) -> Response:
-    """Interactive property tree explorer."""
-    typeahead_js_path = Path(__file__).parent.parent / "static" / "js" / "typeahead_search.js"
-    typeahead_js_source = typeahead_js_path.read_text(encoding="utf-8")
-
-    return request.app.state.templates.TemplateResponse(
-        "properties/tree.html",
-        {
-            "request": request,
-            "typeahead_js_source": typeahead_js_source,
-            "config": request.app.state.config,
-        },
-    )
+    """Redirect to the unified explore tree view."""
+    target = "/explore/tree"
+    node = request.query_params.get("node")
+    if node:
+        target += f"?node={node}&type=property"
+    return RedirectResponse(url=target, status_code=301)
 
 
 @router.get(

--- a/folio_api/routes/properties.py
+++ b/folio_api/routes/properties.py
@@ -73,6 +73,28 @@ def _get_root_properties(folio: FOLIO) -> list[OWLObjectProperty]:
     return roots
 
 
+def _is_in_hidden_branch(folio: FOLIO, prop: OWLObjectProperty) -> bool:
+    """Check if a property is itself hidden or is a descendant of a hidden root."""
+    if prop.iri in HIDDEN_ROOT_PROPERTY_IRIS:
+        return True
+    visited = set()
+    current = prop
+    while current and current.sub_property_of:
+        for parent_iri in current.sub_property_of:
+            if parent_iri == OWL_TOP_OBJECT_PROPERTY or parent_iri in visited:
+                continue
+            if parent_iri in HIDDEN_ROOT_PROPERTY_IRIS:
+                return True
+            visited.add(parent_iri)
+            parent = folio.get_property(parent_iri)
+            if parent:
+                current = parent
+                break
+        else:
+            break
+    return False
+
+
 def _get_child_properties(folio: FOLIO, parent_iri: str, property_children: dict = None) -> list[OWLObjectProperty]:
     """Get child properties of a given parent IRI."""
     if property_children is not None:
@@ -372,7 +394,7 @@ async def search_property_tree(request: Request, query: str) -> JSONResponse:
     query_lower = query.lower()
 
     for prop in folio.object_properties:
-        if prop.iri in seen_iris:
+        if prop.iri in seen_iris or _is_in_hidden_branch(folio, prop):
             continue
 
         label_match = False

--- a/folio_api/routes/properties.py
+++ b/folio_api/routes/properties.py
@@ -1,0 +1,562 @@
+"""
+Property routes for the FOLIO API — browse, tree, and detail views for OWL Object Properties.
+"""
+
+# imports
+from pathlib import Path
+
+# packages
+from fastapi import APIRouter, Request, status
+from folio import FOLIO, OWLObjectProperty
+from starlette.responses import Response, JSONResponse
+
+# project
+from folio_api.rendering import get_property_neighbors, strip_folio_prefix
+
+# API router
+router = APIRouter(prefix="/properties", tags=["properties"])
+
+# The OWL top-level property IRI
+OWL_TOP_OBJECT_PROPERTY = "http://www.w3.org/2002/07/owl#topObjectProperty"
+
+
+def _find_property(folio: FOLIO, iri: str) -> OWLObjectProperty | None:
+    """4-step IRI resolution for properties (mirrors class resolution pattern)."""
+    # Strategy 1: Direct lookup
+    prop = folio.get_property(iri)
+    if prop:
+        return prop
+
+    # Strategy 2: Full IRI → extract ID part
+    if iri.startswith("http"):
+        parts = iri.rstrip("/").split("/")
+        if parts:
+            prop = folio.get_property(parts[-1])
+            if prop:
+                return prop
+
+    # Strategy 3: Short ID → prepend FOLIO prefix
+    if not iri.startswith("http"):
+        full_iri = f"https://folio.openlegalstandard.org/{iri}"
+        prop = folio.get_property(full_iri)
+        if prop:
+            return prop
+
+    # Strategy 4: Scan all properties for suffix match
+    for p in folio.object_properties:
+        if p.iri.endswith(iri) or iri.endswith(p.iri):
+            return p
+
+    return None
+
+
+def _is_root_property(prop: OWLObjectProperty) -> bool:
+    """Check if a property is a root (top-level) property."""
+    if not prop.sub_property_of:
+        return True
+    if len(prop.sub_property_of) == 1 and prop.sub_property_of[0] == OWL_TOP_OBJECT_PROPERTY:
+        return True
+    return False
+
+
+def _get_root_properties(folio: FOLIO) -> list[OWLObjectProperty]:
+    """Get all root-level object properties."""
+    roots = [p for p in folio.object_properties if _is_root_property(p)]
+    roots.sort(key=lambda p: (p.label or p.iri).lower())
+    return roots
+
+
+def _get_child_properties(folio: FOLIO, parent_iri: str, property_children: dict = None) -> list[OWLObjectProperty]:
+    """Get child properties of a given parent IRI."""
+    if property_children is not None:
+        children = property_children.get(parent_iri, [])
+    else:
+        children = [p for p in folio.object_properties if parent_iri in p.sub_property_of]
+    return sorted(children, key=lambda p: (p.label or p.iri).lower())
+
+
+@router.get(
+    "/browse",
+    tags=["properties"],
+    response_model=None,
+    summary="Browse Root Object Properties",
+    description="Browse all root-level OWL object properties in a human-readable HTML format",
+    status_code=status.HTTP_200_OK,
+)
+async def browse_properties(request: Request) -> Response:
+    """Browse all root-level object properties from the FOLIO ontology."""
+    folio: FOLIO = request.app.state.folio
+    property_children = getattr(request.app.state, "property_children", None)
+
+    root_properties = _get_root_properties(folio)
+
+    # Count children for each root property
+    root_data = []
+    for prop in root_properties:
+        children = _get_child_properties(folio, prop.iri, property_children)
+        # Build domain/range summary
+        domain_labels = []
+        for d_iri in prop.domain:
+            cls = folio[d_iri]
+            if cls:
+                domain_labels.append(cls.label or d_iri.split("/")[-1])
+        range_labels = []
+        for r_iri in prop.range:
+            cls = folio[r_iri]
+            if cls:
+                range_labels.append(cls.label or r_iri.split("/")[-1])
+
+        root_data.append({
+            "prop": prop,
+            "child_count": len(children),
+            "domain_summary": ", ".join(domain_labels[:3]) + ("..." if len(domain_labels) > 3 else "") if domain_labels else "",
+            "range_summary": ", ".join(range_labels[:3]) + ("..." if len(range_labels) > 3 else "") if range_labels else "",
+        })
+
+    typeahead_js_path = Path(__file__).parent.parent / "static" / "js" / "typeahead_search.js"
+    typeahead_js_source = typeahead_js_path.read_text(encoding="utf-8")
+
+    return request.app.state.templates.TemplateResponse(
+        "properties/browse.html",
+        {
+            "request": request,
+            "root_data": root_data,
+            "typeahead_js_source": typeahead_js_source,
+            "config": request.app.state.config,
+        },
+    )
+
+
+@router.get(
+    "/tree",
+    tags=["properties"],
+    response_model=None,
+    summary="Interactive Property Tree Explorer",
+    description="Explore FOLIO object properties using an interactive tree view",
+    status_code=status.HTTP_200_OK,
+)
+async def explore_property_tree(request: Request) -> Response:
+    """Interactive property tree explorer."""
+    typeahead_js_path = Path(__file__).parent.parent / "static" / "js" / "typeahead_search.js"
+    typeahead_js_source = typeahead_js_path.read_text(encoding="utf-8")
+
+    return request.app.state.templates.TemplateResponse(
+        "properties/tree.html",
+        {
+            "request": request,
+            "typeahead_js_source": typeahead_js_source,
+            "config": request.app.state.config,
+        },
+    )
+
+
+@router.get(
+    "/tree/data",
+    tags=["properties"],
+    response_model=None,
+    summary="Get Property Tree Data",
+    description="Get hierarchical data for the property tree view",
+    status_code=status.HTTP_200_OK,
+)
+async def get_property_tree_data(request: Request, node_id: str = "#") -> JSONResponse:
+    """Get hierarchical data for the property tree (lazy-load compatible)."""
+    folio: FOLIO = request.app.state.folio
+    property_children = getattr(request.app.state, "property_children", None)
+
+    # INTERIM: strip_folio_prefix calls below can be removed once FOLIO PR #5 is merged
+    if node_id == "#":
+        # Return root properties
+        roots = _get_root_properties(folio)
+        result = []
+        for prop in roots:
+            children = _get_child_properties(folio, prop.iri, property_children)
+            result.append({
+                "id": prop.iri,
+                "text": strip_folio_prefix(prop.label or "Unnamed Property"),
+                "children": len(children) > 0,
+                "data": {
+                    "iri": prop.iri,
+                    "definition": prop.definition or "No definition available",
+                    "type": "root_property",
+                },
+            })
+        return JSONResponse(content=result)
+    else:
+        # Return children of a specific property
+        children = _get_child_properties(folio, node_id, property_children)
+        result = []
+        for child in children:
+            grandchildren = _get_child_properties(folio, child.iri, property_children)
+            result.append({
+                "id": child.iri,
+                "text": strip_folio_prefix(child.label or "Unnamed Property"),
+                "children": len(grandchildren) > 0,
+                "data": {
+                    "iri": child.iri,
+                    "definition": child.definition or "No definition available",
+                    "type": "sub_property",
+                },
+            })
+        return JSONResponse(content=result)
+
+
+@router.get(
+    "/tree/node/{iri:path}",
+    tags=["properties"],
+    response_model=None,
+    summary="Get Single Property Node Data",
+    description="Get detailed data for a single property node",
+    status_code=status.HTTP_200_OK,
+)
+async def get_property_node_data(request: Request, iri: str) -> JSONResponse:
+    """Get detailed data for a single property node by IRI."""
+    folio: FOLIO = request.app.state.folio
+    property_children = getattr(request.app.state, "property_children", None)
+
+    prop = _find_property(folio, iri)
+    if not prop:
+        return JSONResponse(
+            content={"error": f"Property not found for identifier: {iri}"},
+            status_code=status.HTTP_404_NOT_FOUND,
+        )
+
+    nodes, edges = get_property_neighbors(prop, folio, property_children)
+
+    # INTERIM: strip_folio_prefix calls below can be removed once FOLIO PR #5 is merged
+    # Build parent list
+    parents = []
+    for parent_iri in prop.sub_property_of:
+        if parent_iri == OWL_TOP_OBJECT_PROPERTY:
+            continue
+        parent = folio.get_property(parent_iri)
+        if parent:
+            parents.append({
+                "iri": parent.iri,
+                "label": strip_folio_prefix(parent.label or "Unnamed Property"),
+                "definition": parent.definition or "No definition available",
+            })
+    parents.sort(key=lambda x: x["label"].lower())
+
+    # Build children list
+    children_props = _get_child_properties(folio, prop.iri, property_children)
+    children = [
+        {
+            "iri": c.iri,
+            "label": strip_folio_prefix(c.label or "Unnamed Property"),
+            "definition": c.definition or "No definition available",
+        }
+        for c in children_props
+    ]
+
+    # Build domain classes
+    domain_classes = []
+    for d_iri in prop.domain:
+        cls = folio[d_iri]
+        if cls:
+            domain_classes.append({
+                "iri": cls.iri,
+                "label": cls.label or "Unnamed Class",
+                "definition": cls.definition or "No definition available",
+            })
+    domain_classes.sort(key=lambda x: x["label"].lower())
+
+    # Build range classes
+    range_classes = []
+    for r_iri in prop.range:
+        cls = folio[r_iri]
+        if cls:
+            range_classes.append({
+                "iri": cls.iri,
+                "label": cls.label or "Unnamed Class",
+                "definition": cls.definition or "No definition available",
+            })
+    range_classes.sort(key=lambda x: x["label"].lower())
+
+    # Inverse property
+    inverse_data = None
+    if prop.inverse_of:
+        inv = folio.get_property(prop.inverse_of)
+        if inv:
+            inverse_data = {
+                "iri": inv.iri,
+                "label": strip_folio_prefix(inv.label or "Unnamed Property"),
+                "definition": inv.definition or "No definition available",
+            }
+
+    result = {
+        "iri": prop.iri,
+        "label": strip_folio_prefix(prop.label or "Unnamed Property"),
+        "definition": prop.definition or "No definition available",
+        # INTERIM: strip_folio_prefix on preferred_label and alternative_labels can be removed once FOLIO PR #5 is merged
+        "preferred_label": strip_folio_prefix(prop.preferred_label) if prop.preferred_label else None,
+        "alternative_labels": [strip_folio_prefix(al) for al in prop.alternative_labels] if prop.alternative_labels else [],
+        "examples": prop.examples,
+        "parents": parents,
+        "children": children,
+        "domain_classes": domain_classes,
+        "range_classes": range_classes,
+        "inverse": inverse_data,
+        "entity_type": "property",
+        "nodes": nodes,
+        "edges": edges,
+    }
+
+    return JSONResponse(content=result)
+
+
+@router.get(
+    "/tree/path/{iri:path}",
+    tags=["properties"],
+    response_model=None,
+    summary="Get Path to Property Node",
+    description="Get the complete path from root to a specific property in the tree",
+    status_code=status.HTTP_200_OK,
+)
+async def get_property_path(request: Request, iri: str) -> JSONResponse:
+    """Get the complete path from root to a specific property."""
+    folio: FOLIO = request.app.state.folio
+
+    prop = _find_property(folio, iri)
+    if not prop:
+        return JSONResponse(
+            content={"error": f"Property not found for identifier: {iri}"},
+            status_code=status.HTTP_404_NOT_FOUND,
+        )
+
+    path = []
+    current = prop
+
+    path.insert(0, {
+        "iri": current.iri,
+        "label": current.label or "Unnamed Property",
+        "id": current.iri.split("/")[-1] if current.iri.startswith("http") else current.iri,
+    })
+
+    while current and current.sub_property_of:
+        parent_iri = current.sub_property_of[0]
+        if parent_iri == OWL_TOP_OBJECT_PROPERTY:
+            break
+        parent = folio.get_property(parent_iri)
+        if parent:
+            path.insert(0, {
+                "iri": parent.iri,
+                "label": parent.label or "Unnamed Property",
+                "id": parent.iri.split("/")[-1] if parent.iri.startswith("http") else parent.iri,
+            })
+            current = parent
+        else:
+            break
+
+    return JSONResponse(content={"path": path})
+
+
+@router.get(
+    "/tree/search",
+    tags=["properties"],
+    response_model=None,
+    summary="Search Property Tree",
+    description="Search for properties and return a filtered tree structure",
+    status_code=status.HTTP_200_OK,
+)
+async def search_property_tree(request: Request, query: str) -> JSONResponse:
+    """Search for properties and return a filtered tree structure."""
+    folio: FOLIO = request.app.state.folio
+
+    if not query or len(query) < 2:
+        return JSONResponse(content={"matches": [], "tree": {}})
+
+    # Search properties
+    search_results = []
+    seen_iris = set()
+    query_lower = query.lower()
+
+    for prop in folio.object_properties:
+        if prop.iri in seen_iris:
+            continue
+
+        label_match = False
+        if prop.label and query_lower in prop.label.lower():
+            label_match = True
+
+        if not label_match and prop.alternative_labels:
+            for alt in prop.alternative_labels:
+                if alt and query_lower in alt.lower():
+                    label_match = True
+                    break
+
+        if not label_match and prop.definition and query_lower in prop.definition.lower():
+            label_match = True
+
+        if label_match:
+            seen_iris.add(prop.iri)
+            search_results.append(prop)
+
+    if not search_results:
+        return JSONResponse(content={"matches": [], "tree": {}})
+
+    # Build filtered tree
+    included_nodes = set()
+    matches = []
+
+    for prop in search_results:
+        matches.append({
+            "iri": prop.iri,
+            "label": strip_folio_prefix(prop.label or "Unnamed Property"),
+            "definition": prop.definition or "No definition available",
+            "is_match": True,
+        })
+        included_nodes.add(prop.iri)
+
+        # Trace ancestors
+        current = prop
+        while current and current.sub_property_of:
+            for parent_iri in current.sub_property_of:
+                if parent_iri == OWL_TOP_OBJECT_PROPERTY:
+                    continue
+                parent = folio.get_property(parent_iri)
+                if parent:
+                    included_nodes.add(parent_iri)
+                    current = parent
+                    break
+            else:
+                break
+
+    # Build tree structure
+    tree = {"nodes": {}, "root_nodes": []}
+
+    for node_iri in included_nodes:
+        prop = folio.get_property(node_iri)
+        if prop:
+            tree["nodes"][node_iri] = {
+                "id": node_iri,
+                "label": strip_folio_prefix(prop.label or "Unnamed Property"),
+                "children": [],
+                "is_match": any(m["iri"] == node_iri for m in matches),
+            }
+
+    # Build parent-child relationships
+    for node_iri in tree["nodes"]:
+        prop = folio.get_property(node_iri)
+        is_top_level = True
+
+        if prop and prop.sub_property_of:
+            for parent_iri in prop.sub_property_of:
+                if parent_iri == OWL_TOP_OBJECT_PROPERTY:
+                    continue
+                if parent_iri in tree["nodes"]:
+                    tree["nodes"][parent_iri]["children"].append(node_iri)
+                    is_top_level = False
+
+        if is_top_level:
+            tree["root_nodes"].append(node_iri)
+
+    matches.sort(key=lambda x: x["label"].lower())
+
+    # Sort children and root_nodes
+    for node_iri in tree["nodes"]:
+        children = tree["nodes"][node_iri]["children"]
+        if children:
+            children_sorted = sorted(
+                children,
+                key=lambda c: tree["nodes"].get(c, {}).get("label", "").lower()
+            )
+            tree["nodes"][node_iri]["children"] = children_sorted
+
+    tree["root_nodes"] = sorted(
+        tree["root_nodes"],
+        key=lambda n: tree["nodes"].get(n, {}).get("label", "").lower()
+    )
+
+    return JSONResponse(content={"matches": matches, "tree": tree})
+
+
+@router.get(
+    "/property-details/{iri:path}",
+    tags=["properties"],
+    response_model=None,
+    summary="Get Rendered Property Details",
+    description="Get rendered HTML for a property's details using Jinja2 templates",
+    include_in_schema=False,
+)
+async def get_property_details_html(request: Request, iri: str) -> Response:
+    """Get rendered HTML for a specific property's details."""
+    folio: FOLIO = request.app.state.folio
+    property_children = getattr(request.app.state, "property_children", None)
+
+    prop = _find_property(folio, iri)
+    if not prop:
+        return request.app.state.templates.TemplateResponse(
+            "components/property_details.html", {"request": request, "prop_data": None}
+        )
+
+    nodes, edges = get_property_neighbors(prop, folio, property_children)
+
+    # Build parent list
+    parents = []
+    for parent_iri in prop.sub_property_of:
+        if parent_iri == OWL_TOP_OBJECT_PROPERTY:
+            continue
+        parent = folio.get_property(parent_iri)
+        if parent:
+            parents.append({
+                "iri": parent.iri,
+                # INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged
+                "label": strip_folio_prefix(parent.label or "Unnamed Property"),
+                "definition": parent.definition or "No definition available",
+            })
+    parents.sort(key=lambda x: x["label"].lower())
+
+    # Build children
+    children_props = _get_child_properties(folio, prop.iri, property_children)
+    children = [
+        # INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged
+        {"iri": c.iri, "label": strip_folio_prefix(c.label or "Unnamed Property"), "definition": c.definition or "No definition available"}
+        for c in children_props
+    ]
+
+    # Domain classes
+    domain_classes = []
+    for d_iri in prop.domain:
+        cls = folio[d_iri]
+        if cls:
+            domain_classes.append({"iri": cls.iri, "label": cls.label or "Unnamed", "definition": cls.definition or ""})
+    domain_classes.sort(key=lambda x: x["label"].lower())
+
+    # Range classes
+    range_classes = []
+    for r_iri in prop.range:
+        cls = folio[r_iri]
+        if cls:
+            range_classes.append({"iri": cls.iri, "label": cls.label or "Unnamed", "definition": cls.definition or ""})
+    range_classes.sort(key=lambda x: x["label"].lower())
+
+    # Inverse
+    inverse_data = None
+    if prop.inverse_of:
+        inv = folio.get_property(prop.inverse_of)
+        if inv:
+            # INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged
+            inverse_data = {"iri": inv.iri, "label": strip_folio_prefix(inv.label or "Unnamed Property")}
+
+    # INTERIM: strip_folio_prefix calls below can be removed once FOLIO PR #5 is merged
+    prop_data = {
+        "iri": prop.iri,
+        "label": strip_folio_prefix(prop.label or "Unnamed Property"),
+        "definition": prop.definition or "No definition available",
+        "preferred_label": strip_folio_prefix(prop.preferred_label) if prop.preferred_label else None,
+        # INTERIM: strip_folio_prefix on alternative_labels can be removed once FOLIO PR #5 is merged
+        "alternative_labels": [strip_folio_prefix(al) for al in prop.alternative_labels] if prop.alternative_labels else [],
+        "examples": prop.examples,
+        "parents": parents,
+        "children": children,
+        "domain_classes": domain_classes,
+        "range_classes": range_classes,
+        "inverse": inverse_data,
+        "nodes": nodes,
+        "edges": edges,
+    }
+
+    return request.app.state.templates.TemplateResponse(
+        "components/property_details.html",
+        {"request": request, "prop_data": prop_data},
+    )

--- a/folio_api/routes/root.py
+++ b/folio_api/routes/root.py
@@ -7,14 +7,66 @@ import json
 
 # packages
 from fastapi import APIRouter, Request, status
-from folio import FOLIO, OWLClass
+from folio import FOLIO, OWLClass, OWLObjectProperty
 from starlette.responses import JSONResponse, Response
 
 # project
-from folio_api.rendering import get_node_neighbors
+from folio_api.rendering import get_node_neighbors, get_property_neighbors, strip_folio_prefix
 
 # API router
 router = APIRouter(prefix="", tags=["ontology"])
+
+# The OWL top-level property IRI
+OWL_TOP_OBJECT_PROPERTY = "http://www.w3.org/2002/07/owl#topObjectProperty"
+
+
+def _resolve_iri(folio: FOLIO, iri: str):
+    """Resolve an IRI to either a class or property.
+
+    Returns:
+        tuple: (entity, entity_type) where entity_type is "class", "property", or None
+    """
+    # Try class first
+    owl_class = folio[iri]
+    if owl_class:
+        return owl_class, "class"
+
+    # Try property
+    prop = folio.get_property(iri)
+    if prop:
+        return prop, "property"
+
+    # Strategy 2: Extract ID from full IRI
+    if iri.startswith("http"):
+        parts = iri.rstrip("/").split("/")
+        if parts:
+            id_part = parts[-1]
+            owl_class = folio[id_part]
+            if owl_class:
+                return owl_class, "class"
+            prop = folio.get_property(id_part)
+            if prop:
+                return prop, "property"
+
+    # Strategy 3: Prepend FOLIO prefix
+    if not iri.startswith("http"):
+        full_iri = f"https://folio.openlegalstandard.org/{iri}"
+        owl_class = folio[full_iri]
+        if owl_class:
+            return owl_class, "class"
+        prop = folio.get_property(full_iri)
+        if prop:
+            return prop, "property"
+
+    # Strategy 4: Scan all for suffix match
+    for cls in folio.classes:
+        if hasattr(cls, "iri") and (cls.iri.endswith(iri) or iri.endswith(cls.iri)):
+            return cls, "class"
+    for p in folio.object_properties:
+        if p.iri.endswith(iri) or iri.endswith(p.iri):
+            return p, "property"
+
+    return None, None
 
 
 # redirect GET / to /docs
@@ -86,43 +138,28 @@ async def root_redirect() -> Response:
 )
 async def get_class(request: Request, iri: str) -> OWLClass:
     """
-    Retrieve detailed information about a FOLIO ontology class by its IRI identifier in JSON format.
+    Retrieve detailed information about a FOLIO ontology class or property by its IRI in JSON format.
 
-    This endpoint returns comprehensive information about the requested class, including:
+    This endpoint returns comprehensive information about the requested entity, including:
     - Label and definition
-    - Parent and child classes
-    - Properties and relationships
+    - Parent and child relationships
     - Additional metadata
 
-    The IRI parameter is typically the unique identifier for the class, such as `R8pNPutX0TN6DlEqkyZuxSw`.
-
-    Example URLs:
-    - `/R8pNPutX0TN6DlEqkyZuxSw` - Returns the Lessor class
-
-    Example response (partial):
-    ```json
-    {
-      "iri": "R8pNPutX0TN6DlEqkyZuxSw",
-      "label": "Lessor",
-      "definition": "A party that grants a right to use something in return for payment.",
-      "subClassOf": ["oS5FqyVBbOYQbhqb0G28oZR"],
-      "superClassOfIris": ["tBwJ5Vv1FxWdYC7hb3rCJcG"],
-      ...
-    }
-    ```
+    The IRI parameter is typically the unique identifier, such as `R8pNPutX0TN6DlEqkyZuxSw`.
 
     HTTP Status Codes:
-    - 200 OK: Successfully retrieved class information
+    - 200 OK: Successfully retrieved entity information
     - 404 Not Found: The requested IRI does not exist in the ontology
     """
     folio: FOLIO = request.app.state.folio
-    if iri not in folio:
+    entity, entity_type = _resolve_iri(folio, iri)
+    if not entity:
         return JSONResponse(
             status_code=status.HTTP_404_NOT_FOUND,
-            content={"message": "Class not found."},
+            content={"message": "Entity not found."},
         )
 
-    return folio[iri]
+    return entity
 
 
 @router.get(
@@ -149,32 +186,72 @@ async def get_class(request: Request, iri: str) -> OWLClass:
 )
 async def get_class_markdown(request: Request, iri: str) -> Response:
     """
-    Retrieve information about a FOLIO ontology class by its IRI in Markdown format.
-
-    This endpoint returns a Markdown representation of the requested class, suitable for:
-    - Documentation
-    - README files
-    - GitHub or other markdown-compatible platforms
-
-    The Markdown format includes headers, lists, and proper formatting of the class
-    properties and relationships.
-
-    Example URLs:
-    - `/R8pNPutX0TN6DlEqkyZuxSw/markdown` - Returns the Lessor class in Markdown format
+    Retrieve information about a FOLIO ontology entity by its IRI in Markdown format.
 
     HTTP Status Codes:
-    - 200 OK: Successfully retrieved class information in Markdown format
+    - 200 OK: Successfully retrieved entity information in Markdown format
     - 404 Not Found: The requested IRI does not exist in the ontology
     """
     folio: FOLIO = request.app.state.folio
-    if iri not in folio:
+    entity, entity_type = _resolve_iri(folio, iri)
+    if not entity:
         return Response(
             status_code=status.HTTP_404_NOT_FOUND,
-            content="Class not found.",
+            content="Entity not found.",
             media_type="text/plain",
         )
 
-    return Response(content=folio[iri].to_markdown(), media_type="text/markdown")
+    if entity_type == "class":
+        return Response(content=entity.to_markdown(), media_type="text/markdown")
+
+    # Inline markdown for properties (OWLObjectProperty lacks to_markdown())
+    prop = entity
+    # INTERIM: strip_folio_prefix calls below can be removed once FOLIO PR #5 is merged
+    lines = [f"# {strip_folio_prefix(prop.label or 'Unnamed Property')}", ""]
+    lines.append(f"**Type:** OWL Object Property  ")
+    lines.append(f"**IRI:** `{prop.iri}`  ")
+    lines.append("")
+    if prop.definition:
+        lines.append(f"{prop.definition}")
+        lines.append("")
+    if prop.examples:
+        lines.append("## Examples")
+        lines.append("")
+        for ex in prop.examples:
+            lines.append(f"- {ex}")
+        lines.append("")
+    if prop.sub_property_of:
+        lines.append("## Parent Properties")
+        lines.append("")
+        for p_iri in prop.sub_property_of:
+            if p_iri == OWL_TOP_OBJECT_PROPERTY:
+                continue
+            p = folio.get_property(p_iri)
+            # INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged
+            lines.append(f"- {strip_folio_prefix(p.label) if p else p_iri}")
+        lines.append("")
+    if prop.domain:
+        lines.append("## Domain")
+        lines.append("")
+        for d_iri in prop.domain:
+            cls = folio[d_iri]
+            lines.append(f"- {cls.label if cls else d_iri}")
+        lines.append("")
+    if prop.range:
+        lines.append("## Range")
+        lines.append("")
+        for r_iri in prop.range:
+            cls = folio[r_iri]
+            lines.append(f"- {cls.label if cls else r_iri}")
+        lines.append("")
+    if prop.inverse_of:
+        inv = folio.get_property(prop.inverse_of)
+        lines.append(f"## Inverse Of")
+        lines.append("")
+        # INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged
+        lines.append(f"- {strip_folio_prefix(inv.label) if inv else prop.inverse_of}")
+        lines.append("")
+    return Response(content="\n".join(lines), media_type="text/markdown")
 
 
 @router.get(
@@ -207,12 +284,37 @@ async def get_class_jsonld(request: Request, iri: str) -> JSONResponse:
     """
 
     folio: FOLIO = request.app.state.folio
-    if iri not in folio:
-        return JSONResponse(status_code=404, content={"message": "Class not found."})
+    entity, entity_type = _resolve_iri(folio, iri)
+    if not entity:
+        return JSONResponse(status_code=404, content={"message": "Entity not found."})
 
-    return JSONResponse(
-        content=folio[iri].to_jsonld(), media_type="application/ld+json"
-    )
+    if entity_type == "class":
+        return JSONResponse(
+            content=entity.to_jsonld(), media_type="application/ld+json"
+        )
+
+    # Inline JSON-LD for properties
+    prop = entity
+    jsonld = {
+        "@context": {
+            "owl": "http://www.w3.org/2002/07/owl#",
+            "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+            "folio": "https://folio.openlegalstandard.org/",
+        },
+        "@type": "owl:ObjectProperty",
+        "@id": prop.iri,
+        "rdfs:label": prop.label,
+        "rdfs:comment": prop.definition,
+    }
+    if prop.sub_property_of:
+        jsonld["rdfs:subPropertyOf"] = prop.sub_property_of
+    if prop.domain:
+        jsonld["rdfs:domain"] = prop.domain
+    if prop.range:
+        jsonld["rdfs:range"] = prop.range
+    if prop.inverse_of:
+        jsonld["owl:inverseOf"] = prop.inverse_of
+    return JSONResponse(content=jsonld, media_type="application/ld+json")
 
 
 @router.get(
@@ -242,12 +344,38 @@ async def get_class_xml(request: Request, iri: str) -> Response:
     """
 
     folio: FOLIO = request.app.state.folio
-    if iri not in folio:
+    entity, entity_type = _resolve_iri(folio, iri)
+    if not entity:
         return Response(
-            status_code=404, content=json.dumps({"message": "Class not found."})
+            status_code=404, content=json.dumps({"message": "Entity not found."})
         )
 
-    return Response(content=folio[iri].to_owl_xml(), media_type="application/xml")
+    if entity_type == "class":
+        return Response(content=entity.to_owl_xml(), media_type="application/xml")
+
+    # Inline OWL XML for properties
+    prop = entity
+    xml_parts = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        '<Ontology xmlns="http://www.w3.org/2002/07/owl#"',
+        '         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#">',
+        f'  <ObjectProperty IRI="{prop.iri}">',
+    ]
+    if prop.label:
+        xml_parts.append(f'    <rdfs:label>{prop.label}</rdfs:label>')
+    if prop.definition:
+        xml_parts.append(f'    <rdfs:comment>{prop.definition}</rdfs:comment>')
+    for p_iri in prop.sub_property_of:
+        xml_parts.append(f'    <SubObjectPropertyOf IRI="{p_iri}"/>')
+    for d_iri in prop.domain:
+        xml_parts.append(f'    <ObjectPropertyDomain IRI="{d_iri}"/>')
+    for r_iri in prop.range:
+        xml_parts.append(f'    <ObjectPropertyRange IRI="{r_iri}"/>')
+    if prop.inverse_of:
+        xml_parts.append(f'    <InverseObjectProperties IRI="{prop.inverse_of}"/>')
+    xml_parts.append('  </ObjectProperty>')
+    xml_parts.append('</Ontology>')
+    return Response(content="\n".join(xml_parts), media_type="application/xml")
 
 
 @router.get(
@@ -281,14 +409,11 @@ async def get_class_html(request: Request, iri: str) -> Response:
     If the IRI does not exist in the ontology, a 404 error is returned.
     """
     folio: FOLIO = request.app.state.folio
-    if iri not in folio:
+    entity, entity_type = _resolve_iri(folio, iri)
+    if not entity:
         return Response(
-            status_code=404, content=json.dumps({"message": "Class not found."})
+            status_code=404, content=json.dumps({"message": "Entity not found."})
         )
-
-    # Get the class and its graph data
-    owl_class = folio[iri]
-    nodes, edges = get_node_neighbors(owl_class, folio)
 
     # Import JavaScript for typeahead search
     from pathlib import Path
@@ -298,16 +423,97 @@ async def get_class_html(request: Request, iri: str) -> Response:
     )
     typeahead_js_source = typeahead_js_path.read_text(encoding="utf-8")
 
-    # Render using Jinja2 template
+    if entity_type == "class":
+        owl_class = entity
+        nodes, edges = get_node_neighbors(owl_class, folio)
+
+        # Compute cross-linking: properties with this class as domain or range
+        domain_properties = []
+        range_properties = []
+        for p in folio.object_properties:
+            if owl_class.iri in p.domain:
+                # INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged
+                domain_properties.append({"iri": p.iri, "label": strip_folio_prefix(p.label or p.iri)})
+            if owl_class.iri in p.range:
+                # INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged
+                range_properties.append({"iri": p.iri, "label": strip_folio_prefix(p.label or p.iri)})
+        domain_properties.sort(key=lambda x: x["label"].lower())
+        range_properties.sort(key=lambda x: x["label"].lower())
+
+        return request.app.state.templates.TemplateResponse(
+            "taxonomy/class_detail.html",
+            {
+                "request": request,
+                "owl_class": owl_class,
+                "folio_graph": folio,
+                "nodes": nodes,
+                "edges": edges,
+                "config": request.app.state.config,
+                "typeahead_js_source": typeahead_js_source,
+                "domain_properties": domain_properties,
+                "range_properties": range_properties,
+            },
+        )
+
+    # Property HTML rendering
+    prop = entity
+    property_children = getattr(request.app.state, "property_children", None)
+    nodes, edges = get_property_neighbors(prop, folio, property_children)
+
+    # Build parent list
+    parents = []
+    for parent_iri in prop.sub_property_of:
+        if parent_iri == OWL_TOP_OBJECT_PROPERTY:
+            continue
+        parent = folio.get_property(parent_iri)
+        if parent:
+            # INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged
+            parents.append({"iri": parent.iri, "label": strip_folio_prefix(parent.label or "Unnamed Property")})
+    parents.sort(key=lambda x: x["label"].lower())
+
+    # Build children list
+    from folio_api.routes.properties import _get_child_properties
+    children_props = _get_child_properties(folio, prop.iri, property_children)
+    # INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged
+    children = [{"iri": c.iri, "label": strip_folio_prefix(c.label or "Unnamed Property")} for c in children_props]
+
+    # Domain/range classes
+    domain_classes = []
+    for d_iri in prop.domain:
+        cls = folio[d_iri]
+        if cls:
+            domain_classes.append({"iri": cls.iri, "label": cls.label or "Unnamed"})
+    domain_classes.sort(key=lambda x: x["label"].lower())
+
+    range_classes = []
+    for r_iri in prop.range:
+        cls = folio[r_iri]
+        if cls:
+            range_classes.append({"iri": cls.iri, "label": cls.label or "Unnamed"})
+    range_classes.sort(key=lambda x: x["label"].lower())
+
+    # Inverse
+    inverse_data = None
+    if prop.inverse_of:
+        inv = folio.get_property(prop.inverse_of)
+        if inv:
+            # INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged
+            inverse_data = {"iri": inv.iri, "label": strip_folio_prefix(inv.label or "Unnamed Property")}
+
     return request.app.state.templates.TemplateResponse(
-        "taxonomy/class_detail.html",
+        "properties/property_detail.html",
         {
             "request": request,
-            "owl_class": owl_class,
+            "prop": prop,
             "folio_graph": folio,
             "nodes": nodes,
             "edges": edges,
             "config": request.app.state.config,
             "typeahead_js_source": typeahead_js_source,
+            "parents": parents,
+            "children": children,
+            "domain_classes": domain_classes,
+            "range_classes": range_classes,
+            "inverse_data": inverse_data,
         },
     )

--- a/folio_api/routes/search.py
+++ b/folio_api/routes/search.py
@@ -9,7 +9,7 @@ from fastapi import APIRouter, Request, HTTPException, status
 from folio import FOLIO
 
 # project
-from folio_api.models import OWLClassList, OWLSearchResults
+from folio_api.models import OWLClassList, OWLSearchResults, OWLObjectPropertyList
 
 # API router
 router = APIRouter(prefix="/search", tags=["search"])
@@ -195,8 +195,30 @@ async def search_prefix(request: Request, query: str) -> OWLClassList:
     # Combine results, with prefix matches first
     results = prefix_results + label_results
 
+    # Also search properties
+    property_results = []
+    for prop in folio.object_properties:
+        label_match = False
+        if prop.label and (
+            query in prop.label
+            or query_lower in prop.label.lower()
+            or query_title in prop.label
+        ):
+            label_match = True
+        if not label_match and prop.alternative_labels:
+            for alt in prop.alternative_labels:
+                if alt and (
+                    query in alt
+                    or query_lower in alt.lower()
+                    or query_title in alt
+                ):
+                    label_match = True
+                    break
+        if label_match:
+            property_results.append(prop)
+
     # Return 200 OK with results (empty array if no matches)
-    return OWLClassList(classes=results)
+    return OWLClassList(classes=results, properties=property_results)
 
 
 @router.get(

--- a/folio_api/routes/taxonomy.py
+++ b/folio_api/routes/taxonomy.py
@@ -17,6 +17,35 @@ from folio_api.rendering import get_node_neighbors, strip_folio_prefix
 # API router
 router = APIRouter(prefix="/taxonomy", tags=["taxonomy"])
 
+# Curated list of root-level class IRI IDs (direct subclasses of owl:Thing,
+# excluding sandbox/draft classes not ready for public display).
+ROOT_CLASS_IRI_IDS = [
+    "R8CdMpOM0RmyrgCCvbpiLS0",  # Actor / Player
+    "RSYBzf149Mi5KE0YtmpUmr",  # Area of Law
+    "RCIwc6WJi6IT7xePURxsi4T",  # Asset Type
+    "R8qItBwG2pRMFhUq1HQEMnb",  # Communication Modality
+    "R767niCLQVC5zIcO5WDQMSl",  # Currency
+    "R79aItNTJQwHgR002wuX3iC",  # Data Format
+    "RDt4vQCYDfY0R9fZ5FNnTbj",  # Document / Artifact
+    "R9kmGZf5FSmFdouXWQ1Nndm",  # Engagement Attributes
+    "R73hoH1RXYjBTYiGfolpsAF",  # Event
+    "RhBgnef56iLBXYfPqWQE41",  # Financial Concepts and Metrics
+    "RBjHwNNG2ASVmasLFU42otk",  # Forums and Venues
+    "RBQGborh1CfXanGZipDL0Qo",  # Governmental Body
+    "R8f4qGdjxuiQary8OBpq8W9",  # Industry and Market
+    "RDOvAHsvY8TKJ1O1orXPM9o",  # Language
+    "RC1CZydjfH8oiM4W3rCkma3",  # Legal Authorities
+    "R7L5eLIzH0CpOUE74uJvSjL",  # Legal Entity
+    "R9B8sRCK209t5Y8LlU4f62a",  # Legal Use Cases
+    "R9aSzp9cEiBCzObnP92jYFX",  # Location
+    "R7ReDY2v13rer1U8AyOj55L",  # Matter Narrative
+    "RlNFgB3TQfMzV26V4V7u4E",  # Objectives
+    "RDK1QEdQg1T8B5HQqMK2pZN",  # Service
+    "RB4cFSLB4xvycDlKv73dOg6",  # Standards Compatibility
+    "Rx69EnEj3H3TpcgTfUSoYx",  # Status
+    "R8EoZh39tWmXCkmP2Xzjl6E",  # System Identifiers
+]
+
 
 @router.get(
     "/actor_player",
@@ -514,25 +543,12 @@ async def get_tree_data(
 
     # If requesting root nodes
     if node_id == "#":
-        # OWL_THING URI from the FOLIO library
-        OWL_THING = "http://www.w3.org/2002/07/owl#Thing"
-
-        # Filter for classes that are direct subclasses of owl:Thing
-        root_classes = []
-
-        # Get all IRIs from the FOLIO instance
-        for iri in FOLIO_TYPE_IRIS.values():
-            owl_class = folio[iri]
-
-            # Check if this class directly inherits from owl:Thing
-            if hasattr(owl_class, "sub_class_of") and isinstance(
-                owl_class.sub_class_of, list
-            ):
-                if (
-                    len(owl_class.sub_class_of) == 1
-                    and owl_class.sub_class_of[0] == OWL_THING
-                ):
-                    root_classes.append(owl_class)
+        # Look up root classes from curated list
+        root_classes = [
+            folio[iri_id] for iri_id in ROOT_CLASS_IRI_IDS
+            if folio[iri_id] is not None
+        ]
+        root_classes.sort(key=lambda x: (x.label or "").lower())
 
         # Format for jsTree
         result = []
@@ -1286,26 +1302,12 @@ async def browse_top_level_classes(request: Request) -> Response:
     """
     folio: FOLIO = request.app.state.folio
 
-    # OWL_THING URI from the FOLIO library
-    OWL_THING = "http://www.w3.org/2002/07/owl#Thing"
+    # Look up root classes from curated list
+    root_classes = [
+        folio[iri_id] for iri_id in ROOT_CLASS_IRI_IDS
+        if folio[iri_id] is not None
+    ]
 
-    # Filter for classes that are direct subclasses of owl:Thing
-    root_classes = []
-
-    # Get all IRIs from the FOLIO instance
-    for iri in FOLIO_TYPE_IRIS.values():
-        owl_class = folio[iri]
-
-        # Check if this class directly inherits from owl:Thing
-        if hasattr(owl_class, "sub_class_of") and isinstance(
-            owl_class.sub_class_of, list
-        ):
-            if (
-                len(owl_class.sub_class_of) == 1
-                and owl_class.sub_class_of[0] == OWL_THING
-            ):
-                root_classes.append(owl_class)
-    
     # Sort root classes alphabetically by label
     root_classes.sort(key=lambda x: x.label.lower() if x.label else "")
 

--- a/folio_api/routes/taxonomy.py
+++ b/folio_api/routes/taxonomy.py
@@ -8,7 +8,7 @@ from pathlib import Path
 # packages
 from fastapi import APIRouter, Request, status
 from folio import FOLIO, FOLIO_TYPE_IRIS
-from starlette.responses import Response, JSONResponse
+from starlette.responses import Response, JSONResponse, RedirectResponse
 
 # project
 from folio_api.models import OWLClassList
@@ -1248,36 +1248,13 @@ async def get_class_details_html(request: Request, iri: str) -> Response:
     status_code=status.HTTP_200_OK,
 )
 async def explore_taxonomy_tree(request: Request) -> Response:
-    """
-    Interactive taxonomic explorer using jsTree for navigation.
-
-    This endpoint provides an interactive UI for exploring the FOLIO taxonomy hierarchy.
-    The left panel shows a navigable tree view of all classes, while the right panel
-    displays detailed information about the selected class.
-
-    Features:
-    - Lazy-loaded tree for efficient browsing of large hierarchies
-    - Detailed class information in the right panel
-    - Interactive visualization of class relationships
-    - Search functionality
-
-    Returns:
-        Response: HTML page with the interactive taxonomy explorer
-    """
-    # Import JavaScript for tree view
-    typeahead_js_path = (
-        Path(__file__).parent.parent / "static" / "js" / "typeahead_search.js"
-    )
-    typeahead_js_source = typeahead_js_path.read_text(encoding="utf-8")
-
-    return request.app.state.templates.TemplateResponse(
-        "taxonomy/tree.html",
-        {
-            "request": request,
-            "typeahead_js_source": typeahead_js_source,
-            "config": request.app.state.config,
-        },
-    )
+    """Redirect to the unified explore tree view."""
+    # Preserve any query params (e.g. ?node=...)
+    target = "/explore/tree"
+    node = request.query_params.get("node")
+    if node:
+        target += f"?node={node}&type=class"
+    return RedirectResponse(url=target, status_code=301)
 
 
 @router.get(

--- a/folio_api/routes/taxonomy.py
+++ b/folio_api/routes/taxonomy.py
@@ -12,7 +12,7 @@ from starlette.responses import Response, JSONResponse
 
 # project
 from folio_api.models import OWLClassList
-from folio_api.rendering import get_node_neighbors
+from folio_api.rendering import get_node_neighbors, strip_folio_prefix
 
 # API router
 router = APIRouter(prefix="/taxonomy", tags=["taxonomy"])
@@ -1214,12 +1214,27 @@ async def get_class_details_html(request: Request, iri: str) -> Response:
                         "iri": see_also_iri,
                     }
 
+    # Cross-linking: properties with this class as domain or range
+    domain_properties = []
+    range_properties = []
+    for p in folio.object_properties:
+        if owl_class.iri in p.domain:
+            # INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged
+            domain_properties.append({"iri": p.iri, "label": strip_folio_prefix(p.label or p.iri)})
+        if owl_class.iri in p.range:
+            # INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged
+            range_properties.append({"iri": p.iri, "label": strip_folio_prefix(p.label or p.iri)})
+    domain_properties.sort(key=lambda x: x["label"].lower())
+    range_properties.sort(key=lambda x: x["label"].lower())
+
     return request.app.state.templates.TemplateResponse(
         "components/class_details.html",
         {
             "request": request,
             "class_data": class_data,
             "folio_graph": simplified_folio_graph,
+            "domain_properties": domain_properties,
+            "range_properties": range_properties,
         },
     )
 

--- a/folio_api/static/js/property_tree.js
+++ b/folio_api/static/js/property_tree.js
@@ -1,0 +1,817 @@
+/**
+ * Property Tree JavaScript - Handles the tree-based visualization of FOLIO object properties
+ * Adapted from taxonomy_tree.js for property hierarchy navigation
+ */
+
+// Initialize a cache for node data to prevent redundant requests
+const nodeDataCache = new Map();
+const MAX_CACHE_SIZE = 100;
+let isLoadingTree = false;
+const REQUEST_DELAY = 100;
+
+async function getNodeData(nodeId) {
+    if (nodeDataCache.has(nodeId)) {
+        return nodeDataCache.get(nodeId);
+    }
+    const extractedId = extractIdFromIri(nodeId);
+    try {
+        const response = await fetch(`/properties/tree/node/${encodeURIComponent(extractedId)}`);
+        if (!response.ok) throw new Error(`Failed to fetch node data: ${response.status}`);
+        const data = await response.json();
+        nodeDataCache.set(nodeId, data);
+        nodeDataCache.set(extractedId, data);
+        if (nodeDataCache.size > MAX_CACHE_SIZE) {
+            const keys = [...nodeDataCache.keys()];
+            const deleteCount = Math.ceil(MAX_CACHE_SIZE * 0.2);
+            for (let i = 0; i < deleteCount; i++) {
+                nodeDataCache.delete(keys[i]);
+            }
+        }
+        return data;
+    } catch (error) {
+        throw error;
+    }
+}
+
+document.addEventListener('DOMContentLoaded', function() {
+    if (typeof $ === 'undefined') {
+        showFallbackMessage('JavaScript libraries needed for the property tree are not available');
+        return;
+    }
+    const urlParams = new URLSearchParams(window.location.search);
+    const nodeId = urlParams.get('node');
+    if (nodeId) {
+        setupTreeControls();
+        setupKeyboardNavigation();
+        loadAndSelectNode(nodeId, false);
+    } else {
+        initializeTree();
+        setupTreeControls();
+        setupKeyboardNavigation();
+    }
+    setupHistoryNavigation();
+});
+
+function initializeTree() {
+    const treeContainer = $('#taxonomy-tree');
+    treeContainer.html('<ul class="taxonomy-root-list"></ul>');
+    loadTreeNodes('#', $('.taxonomy-root-list'));
+    applyTreeStyles();
+    applyArrowStyles();
+}
+
+function loadTreeNodes(nodeId, container) {
+    const existingNodes = container.children('.tree-node');
+    if (existingNodes.length > 0) return;
+    container.append('<li class="loading-indicator"><span>Loading...</span></li>');
+    fetch('/properties/tree/data?node_id=' + encodeURIComponent(nodeId))
+        .then(response => {
+            if (!response.ok) throw new Error('Network response was not ok');
+            return response.json();
+        })
+        .then(data => {
+            container.find('.loading-indicator').remove();
+            container.children('.tree-node').remove();
+            data.forEach(node => {
+                const existingNode = container.children(`.tree-node[data-id="${node.id}"]`);
+                if (existingNode.length === 0) {
+                    renderTreeNode(node, container);
+                }
+            });
+            setupNodeClickHandlers();
+        })
+        .catch(() => {
+            container.find('.loading-indicator').html('<span class="text-red-500">Error loading. Try again.</span>');
+        });
+}
+
+function renderTreeNode(node, container) {
+    const hasChildren = node.children;
+    const nodeClass = hasChildren ? 'has-children collapsed' : '';
+    const expandIcon = hasChildren ?
+        '<span class="expand-icon"><svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 3 11 8 6 13"></polyline></svg></span>' :
+        '<span class="leaf-indicator"><span class="leaf-dot"></span></span>';
+    const li = $(`
+        <li class="tree-node ${nodeClass}" data-id="${node.id}">
+            <div class="node-content">
+                ${expandIcon}
+                <span class="node-label">${node.text}</span>
+            </div>
+            ${hasChildren ? '<ul class="children-container" style="display:none;"></ul>' : ''}
+        </li>
+    `);
+    container.append(li);
+}
+
+function setupNodeClickHandlers() {
+    try {
+        $('.expand-icon').off('click').on('click', function(e) {
+            e.stopPropagation();
+            const li = $(this).closest('li');
+            if (li.length) toggleNode(li);
+        });
+        $('.node-content').off('click').on('click', function() {
+            const li = $(this).closest('li');
+            if (li.length) selectNode(li);
+        });
+        $('.node-content').off('dblclick').on('dblclick', function(e) {
+            e.stopPropagation();
+            const li = $(this).closest('li');
+            if (li.length && li.hasClass('has-children')) toggleNode(li);
+        });
+    } catch (_) {}
+}
+
+function toggleNode(li) {
+    const nodeId = li.data('id');
+    const childrenContainer = li.find('> .children-container');
+    const expandIcon = li.find('> .node-content .expand-icon');
+    if (li.hasClass('collapsed')) {
+        li.removeClass('collapsed').addClass('expanded');
+        expandIcon.addClass('expanded');
+        childrenContainer.slideDown(200);
+        if (childrenContainer.children('.tree-node').length === 0) {
+            loadTreeNodes(nodeId, childrenContainer);
+        }
+        setTimeout(function() {
+            childrenContainer.find('> li:not(.selected):not(.tree-node-highlighted):not(.tree-node-match) > .node-content').css({
+                'background-color': 'white',
+                'color': 'var(--color-text-default, rgb(16, 16, 16))'
+            });
+        }, 250);
+    } else {
+        li.removeClass('expanded').addClass('collapsed');
+        expandIcon.removeClass('expanded');
+        childrenContainer.slideUp(200);
+    }
+}
+
+function selectNode(li, updateUrl = true) {
+    $('.tree-node.selected').removeClass('selected');
+    li.addClass('selected');
+    const nodeId = li.data('id');
+    loadClassDetails(nodeId, updateUrl);
+    ensureNodeVisible(li);
+}
+
+function ensureNodeVisible(li) {
+    const parents = li.parents('li.tree-node');
+    parents.each(function() {
+        const parent = $(this);
+        if (parent.hasClass('collapsed')) toggleNode(parent);
+    });
+}
+
+function applyTreeStyles() {
+    const style = document.createElement('style');
+    style.textContent = `
+        .taxonomy-root-list, .children-container { list-style-type: none; padding-left: 0; }
+        .children-container { padding-left: 14px; border-left: 1px solid rgba(209, 213, 219, 0.7); margin-left: 6px; }
+        .children-container .tree-node:not(.selected):not(.tree-node-highlighted) > .node-content { background-color: white; color: var(--color-text-default, rgb(16, 16, 16)); }
+        .tree-node { margin: 1px 0; position: relative; }
+        .node-content { display: flex; align-items: center; padding: 2px 6px; border-radius: 3px; cursor: pointer; word-break: break-word; white-space: normal; border-bottom: 1px solid rgba(229, 231, 235, 0.3); line-height: 1.2; }
+        .node-content:hover { background-color: rgba(59, 130, 246, 0.1); }
+        .tree-node.selected > .node-content { background-color: var(--color-primary, rgb(24, 70, 120)) !important; color: white !important; font-weight: 600; }
+        .node-label { flex-grow: 1; }
+        @media (max-width: 768px) {
+            .tree-explorer-container { flex-direction: column; }
+            #tree-container, #detail-container { width: 100%; max-height: none; }
+            #taxonomy-tree { max-height: 400px; }
+        }
+        #taxonomy-tree::-webkit-scrollbar { width: 8px; }
+        #taxonomy-tree::-webkit-scrollbar-track { background: #f1f1f1; border-radius: 4px; }
+        #taxonomy-tree::-webkit-scrollbar-thumb { background: #c1c1c1; border-radius: 4px; }
+        #taxonomy-tree::-webkit-scrollbar-thumb:hover { background: #a8a8a8; }
+        .node-label span.bg-blue-100 { background-color: rgba(229, 231, 235, 0.7); padding: 0 2px; border-radius: 2px; font-weight: bold; color: var(--color-primary, rgb(24, 70, 120)); }
+    `;
+    document.head.appendChild(style);
+}
+
+function applyArrowStyles() {
+    if (!document.getElementById('taxonomy-tree-arrow-styles')) {
+        const arrowStyle = document.createElement('style');
+        arrowStyle.id = 'taxonomy-tree-arrow-styles';
+        arrowStyle.textContent = `
+            .expand-icon { cursor: pointer; width: 20px; height: 20px; display: inline-flex !important; align-items: center !important; justify-content: center; flex-shrink: 0; border-radius: 3px; transition: transform 0.15s ease; color: #6b7280; margin-right: 4px; }
+            .expand-icon:hover { background-color: rgba(107, 114, 128, 0.12); color: #374151; }
+            .expand-icon.expanded { transform: rotate(90deg); }
+            .expand-icon svg { display: block; }
+            .leaf-indicator { width: 20px; height: 20px; display: inline-flex !important; align-items: center !important; justify-content: center; flex-shrink: 0; margin-right: 4px; }
+            .leaf-dot { width: 6px; height: 6px; border-radius: 50%; background-color: #d1d5db; }
+            .tree-node.selected > .node-content .leaf-dot { background-color: rgba(255, 255, 255, 0.6); }
+            .tree-node.selected > .node-content .expand-icon { color: white; }
+        `;
+        document.head.appendChild(arrowStyle);
+    }
+}
+
+function setupSearchHandlers() { return; }
+
+function resetSearch() {
+    const highlightedNodes = document.querySelectorAll('.node-label span.bg-yellow-200');
+    highlightedNodes.forEach(node => {
+        const parent = node.parentElement;
+        parent.innerHTML = parent.textContent;
+    });
+    const hiddenNodes = document.querySelectorAll('.tree-node.search-hidden');
+    hiddenNodes.forEach(node => {
+        node.classList.remove('search-hidden');
+        node.style.display = '';
+    });
+}
+
+function searchTree(query) {
+    if (!query || query.length < 2) { resetSearch(); return; }
+    const totalNodes = $('.node-label').length;
+    if (totalNodes === 0) return;
+    const normalizedQuery = query.toLowerCase();
+    let foundMatches = false;
+    resetSearch();
+    const matchingNodes = new Set();
+    $('.node-label').each(function() {
+        const nodeLabel = $(this);
+        const label = nodeLabel.text();
+        const li = nodeLabel.closest('li');
+        if (label.toLowerCase().includes(normalizedQuery)) {
+            foundMatches = true;
+            matchingNodes.add(li[0]);
+            const regex = new RegExp('(' + escapeRegExp(query) + ')', 'gi');
+            nodeLabel.html(label.replace(regex, '<span class="bg-blue-100">$1</span>'));
+            let parent = li.parents('li');
+            while (parent.length) {
+                matchingNodes.add(parent[0]);
+                parent = parent.parents('li');
+            }
+        }
+    });
+    if (foundMatches) {
+        $('.tree-node').each(function() {
+            if (!matchingNodes.has(this)) {
+                $(this).addClass('search-hidden');
+                $(this).hide();
+            }
+        });
+        matchingNodes.forEach(node => {
+            const $node = $(node);
+            if ($node.hasClass('collapsed')) toggleNode($node);
+        });
+    }
+}
+
+function escapeRegExp(string) {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function setupTreeControls() {
+    const expandAllBtn = document.getElementById('expand-all-btn');
+    if (expandAllBtn) expandAllBtn.addEventListener('click', function() { expandAllNodes(); });
+    const collapseAllBtn = document.getElementById('collapse-all-btn');
+    if (collapseAllBtn) collapseAllBtn.addEventListener('click', function() { collapseAllNodes(); });
+    const expandAllTreeBtn = document.getElementById('expand-all-tree');
+    if (expandAllTreeBtn) expandAllTreeBtn.addEventListener('click', function() { expandAllNodes(); });
+    const collapseAllTreeBtn = document.getElementById('collapse-all-tree');
+    if (collapseAllTreeBtn) collapseAllTreeBtn.addEventListener('click', function() { collapseAllNodes(); });
+}
+
+function expandAllNodes() {
+    const collapsedNodes = $('.tree-node.collapsed');
+    collapsedNodes.each(function() { toggleNode($(this)); });
+}
+
+function collapseAllNodes() {
+    const selectedNodeId = getCurrentSelectedNodeId();
+    let shouldResetUrl = false;
+    if (selectedNodeId) {
+        const selectedNode = $(`.tree-node[data-id="${selectedNodeId}"]`);
+        if (selectedNode.length > 0 && selectedNode.parents('.tree-node').length > 0) {
+            shouldResetUrl = true;
+        }
+    }
+    const expandedNodes = $('.tree-node.expanded');
+    expandedNodes.each(function() { toggleNode($(this)); });
+    if (shouldResetUrl) resetUrlParameters();
+}
+
+function getCurrentSelectedNodeId() {
+    const url = new URL(window.location);
+    const nodeParam = url.searchParams.get('node');
+    if (nodeParam) return nodeParam;
+    const selectedNode = $('.tree-node.selected');
+    if (selectedNode.length > 0) return selectedNode.data('id');
+    return null;
+}
+
+function resetUrlParameters() {
+    const url = new URL(window.location);
+    if (url.searchParams.has('node')) {
+        url.searchParams.delete('node');
+        window.history.replaceState({}, '', url);
+    }
+}
+
+function setupHistoryNavigation() {
+    window.addEventListener('popstate', function(event) {
+        if (event.state && event.state.nodeId) {
+            loadAndSelectNode(event.state.nodeId, false);
+        } else {
+            const urlParams = new URLSearchParams(window.location.search);
+            const nodeId = urlParams.get('node');
+            if (nodeId) {
+                loadAndSelectNode(nodeId, false);
+            } else {
+                const selectedNode = $('.tree-node.selected');
+                if (selectedNode.length > 0) selectedNode.removeClass('selected');
+                const detailsContainer = document.getElementById('class-details');
+                if (detailsContainer) {
+                    detailsContainer.innerHTML = `
+                        <div class="flex items-center justify-center h-full text-gray-500">
+                            <div class="text-center">
+                                <svg class="w-16 h-16 mx-auto text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                                </svg>
+                                <h3 class="mt-2 text-xl font-medium">Select a property</h3>
+                                <p class="mt-1">Choose a property from the tree to view its details</p>
+                            </div>
+                        </div>
+                    `;
+                }
+            }
+        }
+    });
+}
+
+function setupKeyboardNavigation() {
+    document.addEventListener('keydown', function(event) {
+        if (document.activeElement.tagName !== 'INPUT' && document.activeElement.tagName !== 'TEXTAREA') {
+            const selectedNode = document.querySelector('.tree-node.selected');
+            if (selectedNode) {
+                if (event.key === ' ') {
+                    event.preventDefault();
+                    if (selectedNode.classList.contains('has-children')) {
+                        const expandIcon = selectedNode.querySelector('.expand-icon');
+                        if (expandIcon) expandIcon.click();
+                    }
+                } else if (event.key === 'ArrowRight') {
+                    event.preventDefault();
+                    if (selectedNode.classList.contains('has-children') && selectedNode.classList.contains('collapsed')) {
+                        const expandIcon = selectedNode.querySelector('.expand-icon');
+                        if (expandIcon) expandIcon.click();
+                    }
+                } else if (event.key === 'ArrowLeft') {
+                    event.preventDefault();
+                    if (selectedNode.classList.contains('has-children') && selectedNode.classList.contains('expanded')) {
+                        const expandIcon = selectedNode.querySelector('.expand-icon');
+                        if (expandIcon) expandIcon.click();
+                    }
+                } else if (event.key === 'ArrowDown') {
+                    event.preventDefault();
+                    const visibleNodes = Array.from(document.querySelectorAll('.tree-node')).filter(node => window.getComputedStyle(node).display !== 'none');
+                    const currentIndex = visibleNodes.indexOf(selectedNode);
+                    if (currentIndex < visibleNodes.length - 1) {
+                        const nextNode = visibleNodes[currentIndex + 1];
+                        const nodeContent = nextNode.querySelector('.node-content');
+                        if (nodeContent) nodeContent.click();
+                    }
+                } else if (event.key === 'ArrowUp') {
+                    event.preventDefault();
+                    const visibleNodes = Array.from(document.querySelectorAll('.tree-node')).filter(node => window.getComputedStyle(node).display !== 'none');
+                    const currentIndex = visibleNodes.indexOf(selectedNode);
+                    if (currentIndex > 0) {
+                        const prevNode = visibleNodes[currentIndex - 1];
+                        const nodeContent = prevNode.querySelector('.node-content');
+                        if (nodeContent) nodeContent.click();
+                    }
+                }
+            }
+        }
+    });
+}
+
+function loadAndSelectNode(nodeId, updateUrl = true) {
+    if (isLoadingTree) {
+        setTimeout(() => loadAndSelectNode(nodeId, updateUrl), 500);
+        return;
+    }
+    const treeContainer = $('#taxonomy-tree');
+    const needsInitialization = treeContainer.find('.taxonomy-root-list').length === 0;
+    if (needsInitialization) {
+        treeContainer.html('<ul class="taxonomy-root-list"></ul>');
+        applyTreeStyles();
+        applyArrowStyles();
+    }
+    const node = $(`.tree-node[data-id="${nodeId}"]`);
+    if (node.length > 0) {
+        selectNode(node, updateUrl);
+    } else {
+        isLoadingTree = true;
+        const detailsContainer = document.getElementById('class-details');
+        if (detailsContainer) {
+            detailsContainer.innerHTML = `
+                <div class="flex justify-center items-center h-64">
+                    <div class="flex flex-col items-center">
+                        <div class="spinner-border animate-spin inline-block w-8 h-8 border-4 rounded-full text-blue-600 mb-4" role="status">
+                            <span class="sr-only">Loading...</span>
+                        </div>
+                        <p class="text-gray-600">Finding and loading property...</p>
+                    </div>
+                </div>
+            `;
+        }
+        findNodePath(nodeId)
+            .then(path => loadNodePath(path))
+            .then(() => {
+                const loadedNode = $(`.tree-node[data-id="${nodeId}"]`);
+                if (loadedNode.length > 0) {
+                    $('.tree-node.selected').removeClass('selected');
+                    loadedNode.addClass('selected');
+                    loadedNode[0].scrollIntoView({ block: 'center', behavior: 'smooth' });
+                    selectNode(loadedNode, updateUrl);
+                } else {
+                    loadClassDetails(nodeId, updateUrl);
+                }
+            })
+            .catch(err => {
+                const finalCheckNode = $(`.tree-node[data-id="${nodeId}"]`);
+                if (finalCheckNode.length > 0) {
+                    $('.tree-node.selected').removeClass('selected');
+                    finalCheckNode.addClass('selected');
+                    finalCheckNode[0].scrollIntoView({ block: 'center', behavior: 'smooth' });
+                    selectNode(finalCheckNode, updateUrl);
+                } else {
+                    loadClassDetails(nodeId, updateUrl);
+                }
+            })
+            .finally(() => {
+                setTimeout(() => {
+                    const finalNode = $(`.tree-node[data-id="${nodeId}"]`);
+                    if (finalNode.length > 0 && !finalNode.hasClass('selected')) {
+                        $('.tree-node.selected').removeClass('selected');
+                        finalNode.addClass('selected');
+                    }
+                    isLoadingTree = false;
+                }, 200);
+            });
+    }
+}
+
+function extractIdFromIri(iri) {
+    if (!iri || !iri.startsWith('http')) return iri;
+    const parts = iri.split('/').filter(p => p.trim().length > 0);
+    if (parts.length > 0) return parts[parts.length - 1];
+    return iri;
+}
+
+async function findNodePath(nodeId) {
+    const extractedId = extractIdFromIri(nodeId);
+    try {
+        const data = await getNodeData(nodeId);
+        const path = [];
+        if (data.parents && data.parents.length > 0) {
+            const topParent = await findTopLevelParent(data.parents[0].iri);
+            const fullPath = await buildPathToNode(topParent, nodeId);
+            if (fullPath && fullPath.length > 1) {
+                path.push(...fullPath);
+            } else {
+                let currentNode = data.parents[0].iri;
+                const parentChain = [currentNode];
+                try {
+                    for (let i = 0; i < 5; i++) {
+                        const parentData = await getNodeData(currentNode);
+                        if (!parentData.parents || parentData.parents.length === 0) break;
+                        currentNode = parentData.parents[0].iri;
+                        parentChain.unshift(currentNode);
+                    }
+                } catch (error) {}
+                path.push(...parentChain);
+            }
+        }
+        if (path.length === 0 || path[path.length - 1] !== nodeId) {
+            path.push(nodeId);
+        }
+        return path;
+    } catch (error) {
+        return [nodeId];
+    }
+}
+
+async function findTopLevelParent(nodeId) {
+    try {
+        const data = await getNodeData(nodeId);
+        if (!data.parents || data.parents.length === 0 ||
+            data.parents.some(p => p.iri === "http://www.w3.org/2002/07/owl#topObjectProperty")) {
+            return nodeId;
+        }
+        return findTopLevelParent(data.parents[0].iri);
+    } catch (error) {
+        return nodeId;
+    }
+}
+
+async function buildPathToNode(startId, targetId) {
+    if (startId === targetId) return [startId];
+    const extractedStartId = extractIdFromIri(startId);
+    const extractedTargetId = extractIdFromIri(targetId);
+    if (extractedStartId === extractedTargetId) return [startId];
+    const visited = new Set();
+    visited.add(startId);
+    visited.add(extractedStartId);
+    const queue = [[startId, [startId]]];
+    const MAX_DEPTH = 3;
+    try {
+        while (queue.length > 0) {
+            const [currentId, currentPath] = queue.shift();
+            if (currentPath.length > MAX_DEPTH) return [startId];
+            try {
+                const data = await getNodeData(currentId);
+                if (data.children && data.children.length > 0) {
+                    const sortedChildren = [...data.children].sort((a, b) => (a.label || "").localeCompare(b.label || ""));
+                    for (const child of sortedChildren) {
+                        const childId = child.iri;
+                        const extractedChildId = extractIdFromIri(childId);
+                        if (visited.has(childId) || visited.has(extractedChildId)) continue;
+                        visited.add(childId);
+                        visited.add(extractedChildId);
+                        if (childId === targetId || extractedChildId === extractedTargetId) {
+                            return [...currentPath, childId];
+                        }
+                        if (currentPath.length < MAX_DEPTH) {
+                            queue.push([childId, [...currentPath, childId]]);
+                        }
+                    }
+                }
+            } catch (error) { continue; }
+        }
+        return [startId];
+    } catch (error) {
+        return [startId];
+    }
+}
+
+async function loadNodePath(path) {
+    if (!path || path.length === 0) return;
+    const rootList = $('.taxonomy-root-list');
+    let needsRootLoading = rootList.children('.tree-node').length === 0;
+    let container = rootList;
+    if (needsRootLoading) {
+        await new Promise(resolve => {
+            loadTreeNodes('#', container);
+            const checkLoaded = setInterval(() => {
+                if (!container.find('.loading-indicator').length) {
+                    clearInterval(checkLoaded);
+                    resolve();
+                }
+            }, 100);
+        });
+    }
+    let currentContainer = rootList;
+    const startIndex = 0;
+    for (let i = startIndex; i < path.length; i++) {
+        const nodeId = path[i];
+        const isLastNode = (i === path.length - 1);
+        let node = currentContainer.children(`.tree-node[data-id="${nodeId}"]`);
+        if (node.length === 0) node = $(`.tree-node[data-id="${nodeId}"]`);
+        if (node.length > 0) {
+            if (!isLastNode && node.hasClass('collapsed')) toggleNode(node);
+            if (!isLastNode) {
+                currentContainer = node.find('> .children-container');
+                if (currentContainer.length === 0) {
+                    node.append('<ul class="children-container" style="display:block;"></ul>');
+                    currentContainer = node.find('> .children-container');
+                }
+            }
+        } else {
+            const parentNodeId = i > startIndex ? path[i - 1] : '#';
+            await new Promise(resolve => {
+                if (currentContainer.children('.tree-node').length > 0) { resolve(); return; }
+                loadTreeNodes(parentNodeId, currentContainer);
+                const checkLoaded = setInterval(() => {
+                    if (!currentContainer.find('> .loading-indicator').length) {
+                        clearInterval(checkLoaded);
+                        node = currentContainer.children(`.tree-node[data-id="${nodeId}"]`);
+                        if (node.length === 0) node = $(`.tree-node[data-id="${nodeId}"]`);
+                        if (node.length > 0) {
+                            if (!isLastNode && node.hasClass('collapsed')) toggleNode(node);
+                            if (!isLastNode) {
+                                currentContainer = node.find('> .children-container');
+                                if (currentContainer.length === 0) {
+                                    node.append('<ul class="children-container" style="display:block;"></ul>');
+                                    currentContainer = node.find('> .children-container');
+                                }
+                            }
+                        }
+                        resolve();
+                    }
+                }, 100);
+            });
+        }
+    }
+    const targetNodeId = path[path.length - 1];
+    const targetNode = $(`.tree-node[data-id="${targetNodeId}"]`);
+    if (targetNode.length > 0) {
+        targetNode[0].scrollIntoView({ block: 'center', behavior: 'smooth' });
+    }
+}
+
+function loadClassDetails(iri, updateUrl = true) {
+    const detailsContainer = document.getElementById('class-details');
+    if (!detailsContainer) return;
+    if (updateUrl) {
+        const url = new URL(window.location);
+        url.searchParams.set('node', iri);
+        history.pushState({ nodeId: iri }, '', url);
+    }
+    detailsContainer.innerHTML = `
+        <div class="flex justify-center items-center h-64">
+            <div class="spinner-border animate-spin inline-block w-8 h-8 border-4 rounded-full text-blue-600" role="status">
+                <span class="sr-only">Loading...</span>
+            </div>
+        </div>
+    `;
+    let nodeId = iri;
+    if (iri.startsWith('http')) {
+        const parts = iri.split('/').filter(p => p.trim().length > 0);
+        if (parts.length > 0) nodeId = parts[parts.length - 1];
+    }
+    // Fetch the rendered HTML from the server
+    fetch('/properties/property-details/' + encodeURIComponent(nodeId))
+        .then(response => {
+            if (!response.ok) throw new Error('Could not fetch rendered template');
+            return response.text();
+        })
+        .then(html => {
+            detailsContainer.innerHTML = html;
+        })
+        .catch(() => {
+            // Fallback: try fetching JSON data and render client-side
+            fetch('/properties/tree/node/' + encodeURIComponent(nodeId))
+                .then(response => {
+                    if (!response.ok) throw new Error('Network response was not ok');
+                    return response.json();
+                })
+                .then(data => {
+                    fallbackRenderPropertyDetails(data, detailsContainer);
+                })
+                .catch(() => {
+                    detailsContainer.innerHTML = `
+                        <div class="p-4 text-red-500">
+                            <h3 class="text-xl font-medium mb-2">Error loading property details</h3>
+                            <p>Unable to load details for this property. Please try again or select a different property.</p>
+                        </div>
+                    `;
+                });
+        });
+}
+
+function selectNodeByIri(iri) {
+    loadAndSelectNode(iri);
+}
+
+function fallbackRenderPropertyDetails(data, container) {
+    let parentsHtml = '';
+    if (data.parents && data.parents.length > 0) {
+        parentsHtml = `
+            <section class="card animate-fade-in mb-6">
+                <h4 class="text-lg font-medium text-[--color-primary] mb-3">Parent Properties</h4>
+                <div class="max-h-[200px] overflow-y-auto pr-1">
+                    <ul class="space-y-2">
+                        ${data.parents.map(parent =>
+                            `<li class="group p-1.5 -ml-1.5 rounded-md hover:bg-blue-50">
+                                <div class="flex items-start">
+                                    <svg class="w-4 h-4 mt-1 mr-2 text-blue-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 11l5-5m0 0l5 5m-5-5v12" />
+                                    </svg>
+                                    <div>
+                                        <a href="#" class="font-medium text-blue-600 hover:text-blue-800 group-hover:underline" onclick="selectNodeByIri('${parent.iri}'); return false;">${parent.label}</a>
+                                        <p class="text-sm text-gray-600 mt-0.5 line-clamp-2">${parent.definition}</p>
+                                    </div>
+                                </div>
+                            </li>`
+                        ).join('')}
+                    </ul>
+                </div>
+            </section>
+        `;
+    }
+
+    let childrenHtml = '';
+    if (data.children && data.children.length > 0) {
+        childrenHtml = `
+            <section class="card animate-fade-in mb-6">
+                <h4 class="text-lg font-medium text-[--color-primary] mb-3 flex items-center">
+                    Child Properties
+                    <span class="ml-2 px-1.5 py-0.5 text-xs font-semibold bg-blue-100 text-blue-800 rounded-full">${data.children.length}</span>
+                </h4>
+                <div class="max-h-[300px] overflow-y-auto pr-1">
+                    <ul class="space-y-2">
+                        ${data.children.map(child =>
+                            `<li class="group p-1.5 -ml-1.5 rounded-md hover:bg-blue-50">
+                                <div class="flex items-start">
+                                    <svg class="w-4 h-4 mt-1 mr-2 text-green-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 13l-5 5m0 0l-5-5m5 5V6" />
+                                    </svg>
+                                    <div>
+                                        <a href="#" class="font-medium text-blue-600 hover:text-blue-800 group-hover:underline" onclick="selectNodeByIri('${child.iri}'); return false;">${child.label}</a>
+                                        <p class="text-sm text-gray-600 mt-0.5 line-clamp-2">${child.definition}</p>
+                                    </div>
+                                </div>
+                            </li>`
+                        ).join('')}
+                    </ul>
+                </div>
+            </section>
+        `;
+    }
+
+    let domainHtml = '';
+    if (data.domain_classes && data.domain_classes.length > 0) {
+        domainHtml = `
+            <section class="card animate-fade-in mb-6">
+                <h4 class="text-lg font-medium text-[--color-primary] mb-3">Domain Classes <span class="ml-2 px-1.5 py-0.5 text-xs font-semibold bg-teal-100 text-teal-800 rounded-full">${data.domain_classes.length}</span></h4>
+                <div class="max-h-[200px] overflow-y-auto pr-1">
+                    <ul class="space-y-1">
+                        ${data.domain_classes.map(cls =>
+                            `<li class="flex items-center"><span class="text-teal-500 mr-2">&bull;</span><a href="${cls.iri}/html" class="text-teal-700 hover:underline">${cls.label}</a></li>`
+                        ).join('')}
+                    </ul>
+                </div>
+            </section>
+        `;
+    }
+
+    let rangeHtml = '';
+    if (data.range_classes && data.range_classes.length > 0) {
+        rangeHtml = `
+            <section class="card animate-fade-in mb-6">
+                <h4 class="text-lg font-medium text-[--color-primary] mb-3">Range Classes <span class="ml-2 px-1.5 py-0.5 text-xs font-semibold bg-orange-100 text-orange-800 rounded-full">${data.range_classes.length}</span></h4>
+                <div class="max-h-[200px] overflow-y-auto pr-1">
+                    <ul class="space-y-1">
+                        ${data.range_classes.map(cls =>
+                            `<li class="flex items-center"><span class="text-orange-500 mr-2">&bull;</span><a href="${cls.iri}/html" class="text-orange-700 hover:underline">${cls.label}</a></li>`
+                        ).join('')}
+                    </ul>
+                </div>
+            </section>
+        `;
+    }
+
+    let inverseHtml = '';
+    if (data.inverse) {
+        inverseHtml = `
+            <section class="card animate-fade-in mb-6">
+                <h4 class="text-lg font-medium text-[--color-primary] mb-3">Inverse Property</h4>
+                <div class="bg-purple-50 rounded-lg p-4">
+                    <a href="#" class="font-medium text-purple-700 hover:underline" onclick="selectNodeByIri('${data.inverse.iri}'); return false;">${data.inverse.label}</a>
+                </div>
+            </section>
+        `;
+    }
+
+    const examplesHtml = data.examples && data.examples.length > 0 ?
+        `<section class="card animate-fade-in mb-6">
+            <h4 class="text-lg font-medium text-[--color-primary] mb-3">Examples</h4>
+            <div class="bg-green-50 border border-green-100 rounded-md p-2">
+                <ul class="space-y-2.5">
+                    ${data.examples.map(example => `<li class="flex items-start"><span class="text-green-500 mr-2">&bull;</span><span>${example}</span></li>`).join('')}
+                </ul>
+            </div>
+        </section>` : '';
+
+    container.innerHTML = `
+        <section class="card animate-fade-in mb-6 border-t-4 border-[--color-primary]">
+            <div class="flex items-center mb-2">
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800 mr-2">Property</span>
+                <h3 class="text-2xl font-semibold text-[--color-primary]">${data.label}</h3>
+            </div>
+            <div class="flex items-center text-gray-500 text-sm mb-4">
+                <span class="font-medium mr-1.5">IRI:</span>
+                <span class="font-mono truncate max-w-[450px]" title="${data.iri}">${data.iri}</span>
+                <button onclick="navigator.clipboard.writeText('${data.iri}')" class="ml-2 py-1 px-2 rounded text-blue-600 hover:bg-blue-50" aria-label="Copy IRI">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+                    </svg>
+                </button>
+            </div>
+            <div class="prose max-w-none mt-2 bg-gray-50 p-3 rounded-md border-l-4 border-blue-200">
+                <p class="text-gray-800">${data.definition}</p>
+            </div>
+        </section>
+        <div class="grid grid-cols-1 xl:grid-cols-2 gap-6 w-full" id="detail-grid">
+            <div>${parentsHtml}${inverseHtml}${domainHtml}</div>
+            <div>${childrenHtml}${rangeHtml}${examplesHtml}</div>
+        </div>
+    `;
+}
+
+function showFallbackMessage(message) {
+    const treeContainer = document.getElementById('taxonomy-tree');
+    if (!treeContainer) return;
+    treeContainer.innerHTML = `
+        <div class="p-4 text-yellow-800 bg-yellow-100 rounded">
+            <h3 class="font-medium">Unable to load property tree</h3>
+            <p>${message}</p>
+            <p class="mt-2"><a href="/properties/browse" class="text-blue-600 hover:underline">Switch to the standard browse view</a></p>
+        </div>
+    `;
+}
+
+window.selectNodeByIri = selectNodeByIri;

--- a/folio_api/static/js/split_pane.js
+++ b/folio_api/static/js/split_pane.js
@@ -1,0 +1,123 @@
+/**
+ * Draggable split-pane resizer with localStorage persistence.
+ *
+ * Usage:
+ *   initSplitPane({ storageKey: 'folio-taxonomy-split', defaultPct: 25 });
+ *
+ * - Inserts a drag handle between #tree-container and #detail-container.
+ * - Saves the tree-panel width (%) to localStorage on every drag.
+ * - Restores width from localStorage on page load.
+ * - Double-click the handle to reset to the default width.
+ * - Disabled on mobile (< 768 px) where the panels stack vertically.
+ */
+function initSplitPane(opts) {
+    const storageKey = opts.storageKey || 'folio-split-pct';
+    const defaultPct = opts.defaultPct || 25;
+    const minPct = opts.minPct || 15;
+    const maxPct = opts.maxPct || 55;
+
+    const container = document.querySelector('.tree-explorer-container');
+    const treePanel = document.getElementById('tree-container');
+    const detailPanel = document.getElementById('detail-container');
+    if (!container || !treePanel || !detailPanel) return;
+
+    // --- Create handle ---
+    const handle = document.createElement('div');
+    handle.className = 'split-handle';
+    handle.title = 'Drag to resize \u00b7 Double-click to reset';
+    treePanel.after(handle);
+
+    // --- Apply width ---
+    function applyWidth(pct) {
+        treePanel.style.flex = 'none';
+        treePanel.style.width = pct + '%';
+        detailPanel.style.flex = '1';
+        detailPanel.style.width = 'auto';
+    }
+
+    function isDesktop() {
+        return window.innerWidth >= 768;
+    }
+
+    function activate() {
+        const saved = localStorage.getItem(storageKey);
+        const pct = saved ? parseFloat(saved) : defaultPct;
+        applyWidth(pct);
+        handle.style.display = '';
+    }
+
+    function deactivate() {
+        // Remove inline overrides so Tailwind classes take over
+        treePanel.style.flex = '';
+        treePanel.style.width = '';
+        detailPanel.style.flex = '';
+        detailPanel.style.width = '';
+        handle.style.display = 'none';
+    }
+
+    if (isDesktop()) {
+        activate();
+    } else {
+        handle.style.display = 'none';
+    }
+
+    // --- Drag state ---
+    let dragging = false;
+
+    function onPointerDown(e) {
+        if (!isDesktop()) return;
+        dragging = true;
+        document.body.style.cursor = 'col-resize';
+        document.body.style.userSelect = 'none';
+        // Prevent iframe / selection interference
+        detailPanel.style.pointerEvents = 'none';
+        e.preventDefault();
+    }
+
+    function onPointerMove(e) {
+        if (!dragging) return;
+        const rect = container.getBoundingClientRect();
+        let pct = ((e.clientX - rect.left) / rect.width) * 100;
+        pct = Math.max(minPct, Math.min(maxPct, pct));
+        applyWidth(pct);
+        localStorage.setItem(storageKey, pct.toFixed(2));
+    }
+
+    function onPointerUp() {
+        if (!dragging) return;
+        dragging = false;
+        document.body.style.cursor = '';
+        document.body.style.userSelect = '';
+        detailPanel.style.pointerEvents = '';
+    }
+
+    // Mouse events
+    handle.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('mousemove', onPointerMove);
+    document.addEventListener('mouseup', onPointerUp);
+
+    // Touch events (tablets in landscape)
+    handle.addEventListener('touchstart', function (e) {
+        onPointerDown(e.touches[0]);
+        e.preventDefault();
+    }, { passive: false });
+    document.addEventListener('touchmove', function (e) {
+        if (dragging) onPointerMove(e.touches[0]);
+    }, { passive: true });
+    document.addEventListener('touchend', onPointerUp);
+
+    // Double-click to reset
+    handle.addEventListener('dblclick', function () {
+        applyWidth(defaultPct);
+        localStorage.setItem(storageKey, defaultPct);
+    });
+
+    // Respond to viewport changes
+    window.addEventListener('resize', function () {
+        if (isDesktop()) {
+            activate();
+        } else {
+            deactivate();
+        }
+    });
+}

--- a/folio_api/static/js/taxonomy_tree.js
+++ b/folio_api/static/js/taxonomy_tree.js
@@ -1705,12 +1705,12 @@ function fallbackRenderClassDetails(data, container) {
             const flag = languageFlags[langLower] || "🌐";
             
             translationItems += `
-                <div class="bg-gray-50 rounded p-3 border-l-2 border-blue-300">
-                    <div class="flex items-center mb-2">
+                <div class="bg-gray-50 rounded px-3 py-1.5 border-l-2 border-blue-300">
+                    <div class="flex items-center">
                         <span class="text-lg mr-2">${flag}</span>
-                        <p class="text-gray-700 font-medium">${lang}</p>
+                        <span class="text-gray-500 font-mono text-sm w-12 flex-shrink-0">${lang}</span>
+                        <span class="text-gray-800 italic ml-2">${translation}</span>
                     </div>
-                    <p class="text-gray-800 italic">${translation}</p>
                 </div>
             `;
         }

--- a/folio_api/static/js/taxonomy_tree.js
+++ b/folio_api/static/js/taxonomy_tree.js
@@ -153,9 +153,9 @@ function loadTreeNodes(nodeId, container) {
 function renderTreeNode(node, container) {
     const hasChildren = node.children;
     const nodeClass = hasChildren ? 'has-children collapsed' : '';
-    const expandIcon = hasChildren ? 
-        '<span class="expand-icon mr-1">▸</span>' : 
-        '<span class="leaf-indicator ml-1 mr-3 inline-flex shrink-0 items-center justify-center w-[8px] h-[8px] rounded-full bg-gray-200"></span>';
+    const expandIcon = hasChildren ?
+        '<span class="expand-icon"><svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 3 11 8 6 13"></polyline></svg></span>' :
+        '<span class="leaf-indicator"><span class="leaf-dot"></span></span>';
     
     const li = $(`
         <li class="tree-node ${nodeClass}" data-id="${node.id}">
@@ -219,7 +219,7 @@ function toggleNode(li) {
     if (li.hasClass('collapsed')) {
         // Expand the node
         li.removeClass('collapsed').addClass('expanded');
-        expandIcon.html('▾');
+        expandIcon.addClass('expanded');
         childrenContainer.slideDown(200);
         
         // Load children if not already loaded - only if there are no tree nodes
@@ -238,7 +238,7 @@ function toggleNode(li) {
     } else {
         // Collapse the node
         li.removeClass('expanded').addClass('collapsed');
-        expandIcon.html('▸');
+        expandIcon.removeClass('expanded');
         childrenContainer.slideUp(200);
     }
 }
@@ -380,17 +380,47 @@ function applyArrowStyles() {
         arrowStyle.textContent = `
             .expand-icon {
                 cursor: pointer;
-                width: 16px;
+                width: 20px;
+                height: 20px;
                 display: inline-flex !important;
                 align-items: center !important;
                 justify-content: center;
-                text-align: center;
                 flex-shrink: 0;
-                font-size: 24px !important;
-                line-height: 16px !important;
-                vertical-align: middle !important;
-                position: relative !important;
-                top: -2px !important;
+                border-radius: 3px;
+                transition: transform 0.15s ease;
+                color: #6b7280;
+                margin-right: 4px;
+            }
+            .expand-icon:hover {
+                background-color: rgba(107, 114, 128, 0.12);
+                color: #374151;
+            }
+            .expand-icon.expanded {
+                transform: rotate(90deg);
+            }
+            .expand-icon svg {
+                display: block;
+            }
+            .leaf-indicator {
+                width: 20px;
+                height: 20px;
+                display: inline-flex !important;
+                align-items: center !important;
+                justify-content: center;
+                flex-shrink: 0;
+                margin-right: 4px;
+            }
+            .leaf-dot {
+                width: 6px;
+                height: 6px;
+                border-radius: 50%;
+                background-color: #d1d5db;
+            }
+            .tree-node.selected > .node-content .leaf-dot {
+                background-color: rgba(255, 255, 255, 0.6);
+            }
+            .tree-node.selected > .node-content .expand-icon {
+                color: white;
             }
         `;
         document.head.appendChild(arrowStyle);

--- a/folio_api/static/js/typeahead_search.js
+++ b/folio_api/static/js/typeahead_search.js
@@ -9,6 +9,18 @@
     });
     
     /**
+     * INTERIM FIX: Strip 'folio:' prefix from property labels for human-readable display.
+     * Remove this function once https://github.com/alea-institute/FOLIO/pull/5 is merged
+     * and folio-python is updated with human-readable rdfs:label values.
+     */
+    function stripFolioPrefix(label) {
+        if (label && label.startsWith('folio:')) {
+            return label.substring(6);
+        }
+        return label || '';
+    }
+
+    /**
      * Initializes typeahead search functionality
      */
     function initializeTypeahead() {
@@ -85,24 +97,42 @@
                     // track seen IRIs
                     let seen = {};
                     let search_results = [];
-    
+
                     for (let c of response.classes) {
                         // check if we've seen it already
                         if (seen[c.iri]) {
                             // skip it
                         } else {
                             seen[c.iri] = true;
-    
+
                             let label = c.label || c.preferred_label || (c.alternative_labels && c.alternative_labels[0]) || c.iri;
                             search_results.push({
                                 label: label,
                                 iri: c.iri,
+                                entity_type: 'Class',
                                 alternative_labels: c.alternative_labels && c.alternative_labels.length ? c.alternative_labels.join(', ') : 'None',
                                 definition: c.definition || 'No definition available'
                             });
                         }
                     }
-    
+
+                    // Also include properties
+                    if (response.properties) {
+                        for (let p of response.properties) {
+                            if (seen[p.iri]) continue;
+                            seen[p.iri] = true;
+                            // INTERIM: stripFolioPrefix can be removed once FOLIO PR #5 is merged
+                            let label = stripFolioPrefix(p.label || p.preferred_label || (p.alternative_labels && p.alternative_labels[0]) || p.iri);
+                            search_results.push({
+                                label: label,
+                                iri: p.iri,
+                                entity_type: 'Property',
+                                alternative_labels: p.alternative_labels && p.alternative_labels.length ? p.alternative_labels.join(', ') : 'None',
+                                definition: p.definition || 'No definition available'
+                            });
+                        }
+                    }
+
                     return search_results;
                 }
             }
@@ -123,24 +153,30 @@
                         // Highlight the matching part of the label if possible
                         let label = data.label;
                         const query = $('#search-input').val().trim().toLowerCase();
-                        
+
                         if (query && query.length > 0 && label) {
                             // Try to highlight the query within the label
                             const labelLower = label.toLowerCase();
                             const index = labelLower.indexOf(query);
-                            
+
                             if (index >= 0) {
                                 const beforeMatch = label.substring(0, index);
                                 const match = label.substring(index, index + query.length);
                                 const afterMatch = label.substring(index + query.length);
-                                
+
                                 label = `${beforeMatch}<span class="bg-yellow-200 text-black">${match}</span>${afterMatch}`;
                             }
                         }
-                        
+
+                        // Type badge
+                        const isProperty = data.entity_type === 'Property';
+                        const badgeColor = isProperty ? 'bg-teal-100 text-teal-800' : 'bg-blue-100 text-blue-800';
+                        const badgeText = isProperty ? 'Property' : 'Class';
+                        const badge = `<span class="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium ${badgeColor} ml-2">${badgeText}</span>`;
+
                         return `
                             <div class="flex flex-col p-2 hover:bg-gray-100">
-                                <span class="font-semibold text-[--color-primary]">${label}</span>
+                                <span class="font-semibold text-[--color-primary]">${label}${badge}</span>
                                 <span class="text-sm font-semibold text-[--color-text-secondary] truncate">${data.iri}</span>
                                 <span class="text-sm font-light text-[--color-text-muted] truncate">Synonyms: ${data.alternative_labels}</span>
                                 <span class="text-sm font-light text-[--color-text-muted] truncate">Definition: ${data.definition}</span>

--- a/folio_api/static/js/unified_tree.js
+++ b/folio_api/static/js/unified_tree.js
@@ -785,16 +785,10 @@ function hasMatchDescendant(nodeId, treeData) {
     return false;
 }
 
-function toggleSearchClearButtons(showClear) {
-    const searchBtn = document.getElementById('explore-search-button');
-    const clearBtn = document.getElementById('explore-search-clear');
-    if (searchBtn) searchBtn.style.display = showClear ? 'none' : 'flex';
-    if (clearBtn) clearBtn.style.display = showClear ? 'flex' : 'none';
-}
-
 function addFilterModeControls(totalCount, query, classCount, propCount) {
-    // Show Clear button, hide Search button
-    toggleSearchClearButtons(true);
+    // Show the inline clear (X) button inside the search input
+    const clearBtn = document.getElementById('explore-search-clear');
+    if (clearBtn) clearBtn.style.display = 'flex';
 
     // Build match-count text
     let detail = totalCount + ' match' + (totalCount !== 1 ? 'es' : '');
@@ -820,8 +814,9 @@ function addFilterModeControls(totalCount, query, classCount, propCount) {
 }
 
 function clearFilterMode() {
-    // Hide Clear button, show Search button
-    toggleSearchClearButtons(false);
+    // Hide inline clear button and match count
+    const clearBtn = document.getElementById('explore-search-clear');
+    if (clearBtn) clearBtn.style.display = 'none';
     const countEl = document.getElementById('search-match-count');
     if (countEl) { countEl.textContent = ''; countEl.style.display = 'none'; }
 

--- a/folio_api/static/js/unified_tree.js
+++ b/folio_api/static/js/unified_tree.js
@@ -785,10 +785,16 @@ function hasMatchDescendant(nodeId, treeData) {
     return false;
 }
 
-function addFilterModeControls(totalCount, query, classCount, propCount) {
-    // Show the inline clear (X) button inside the search input
+function toggleSearchClearButtons(showClear) {
+    const searchBtn = document.getElementById('explore-search-button');
     const clearBtn = document.getElementById('explore-search-clear');
-    if (clearBtn) clearBtn.style.display = 'flex';
+    if (searchBtn) searchBtn.style.display = showClear ? 'none' : 'flex';
+    if (clearBtn) clearBtn.style.display = showClear ? 'flex' : 'none';
+}
+
+function addFilterModeControls(totalCount, query, classCount, propCount) {
+    // Show Clear button, hide Search button
+    toggleSearchClearButtons(true);
 
     // Build match-count text
     let detail = totalCount + ' match' + (totalCount !== 1 ? 'es' : '');
@@ -814,9 +820,8 @@ function addFilterModeControls(totalCount, query, classCount, propCount) {
 }
 
 function clearFilterMode() {
-    // Hide inline clear button and match count
-    const clearBtn = document.getElementById('explore-search-clear');
-    if (clearBtn) clearBtn.style.display = 'none';
+    // Hide Clear button, show Search button
+    toggleSearchClearButtons(false);
     const countEl = document.getElementById('search-match-count');
     if (countEl) { countEl.textContent = ''; countEl.style.display = 'none'; }
 

--- a/folio_api/static/js/unified_tree.js
+++ b/folio_api/static/js/unified_tree.js
@@ -1,0 +1,899 @@
+/**
+ * Unified Tree JavaScript — Combined class + property tree in one view.
+ * Parameterized by section config so both types share the same tree logic.
+ */
+
+// Section configuration — maps each entity type to its API endpoints and DOM ids
+const SECTIONS = {
+    class: {
+        rootListId: 'class-tree-root',
+        sectionId: 'class-section',
+        countId: 'class-count',
+        treeDataEndpoint: '/taxonomy/tree/data',
+        nodeDataEndpoint: '/taxonomy/tree/node/',
+        detailsEndpoint: '/taxonomy/class-details/',
+        searchEndpoint: '/taxonomy/tree/search',
+        pathEndpoint: '/taxonomy/tree/path/',
+        type: 'class'
+    },
+    property: {
+        rootListId: 'property-tree-root',
+        sectionId: 'property-section',
+        countId: 'property-count',
+        treeDataEndpoint: '/properties/tree/data',
+        nodeDataEndpoint: '/properties/tree/node/',
+        detailsEndpoint: '/properties/property-details/',
+        searchEndpoint: '/properties/tree/search',
+        pathEndpoint: '/properties/tree/path/',
+        type: 'property'
+    }
+};
+
+// Cache and state
+const nodeDataCache = new Map();
+const MAX_CACHE_SIZE = 200;
+let isLoadingTree = false;
+
+// ---------- Cache helper ----------
+async function getNodeData(nodeId, sectionType) {
+    const cacheKey = sectionType + ':' + nodeId;
+    if (nodeDataCache.has(cacheKey)) return nodeDataCache.get(cacheKey);
+
+    const cfg = SECTIONS[sectionType];
+    const extractedId = extractIdFromIri(nodeId);
+    const response = await fetch(cfg.nodeDataEndpoint + encodeURIComponent(extractedId));
+    if (!response.ok) throw new Error('Failed to fetch node data: ' + response.status);
+    const data = await response.json();
+
+    nodeDataCache.set(cacheKey, data);
+    nodeDataCache.set(sectionType + ':' + extractedId, data);
+
+    // Prune cache
+    if (nodeDataCache.size > MAX_CACHE_SIZE) {
+        const keys = [...nodeDataCache.keys()];
+        const deleteCount = Math.ceil(MAX_CACHE_SIZE * 0.2);
+        for (let i = 0; i < deleteCount; i++) nodeDataCache.delete(keys[i]);
+    }
+    return data;
+}
+
+// ---------- IRI helpers ----------
+function extractIdFromIri(iri) {
+    if (!iri || !iri.startsWith('http')) return iri;
+    const parts = iri.split('/').filter(p => p.trim().length > 0);
+    return parts.length > 0 ? parts[parts.length - 1] : iri;
+}
+
+// ---------- Section collapse/expand ----------
+function setupSectionHeaders() {
+    document.querySelectorAll('.section-header').forEach(header => {
+        header.addEventListener('click', () => {
+            const sectionType = header.dataset.section;
+            const cfg = SECTIONS[sectionType];
+            const rootList = document.getElementById(cfg.rootListId);
+            const chevron = header.querySelector('.section-chevron');
+            if (rootList.style.display === 'none') {
+                rootList.style.display = '';
+                chevron.classList.remove('collapsed');
+            } else {
+                rootList.style.display = 'none';
+                chevron.classList.add('collapsed');
+            }
+        });
+    });
+}
+
+// ---------- Tree node rendering ----------
+function renderTreeNode(node, container, sectionType) {
+    const hasChildren = node.children;
+    const nodeClass = hasChildren ? 'has-children collapsed' : '';
+    const expandIcon = hasChildren
+        ? '<span class="expand-icon"><svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 3 11 8 6 13"></polyline></svg></span>'
+        : '<span class="leaf-indicator"><span class="leaf-dot"></span></span>';
+
+    const li = $(`
+        <li class="tree-node ${nodeClass}" data-id="${node.id}" data-type="${sectionType}">
+            <div class="node-content">
+                ${expandIcon}
+                <span class="node-label">${node.text}</span>
+            </div>
+            ${hasChildren ? '<ul class="children-container" style="display:none;"></ul>' : ''}
+        </li>
+    `);
+    container.append(li);
+}
+
+function loadTreeNodes(nodeId, container, sectionType) {
+    if (container.children('.tree-node').length > 0) return;
+    container.append('<li class="loading-indicator"><span>Loading...</span></li>');
+
+    const cfg = SECTIONS[sectionType];
+    fetch(cfg.treeDataEndpoint + '?node_id=' + encodeURIComponent(nodeId))
+        .then(r => { if (!r.ok) throw new Error('Network error'); return r.json(); })
+        .then(data => {
+            container.find('.loading-indicator').remove();
+            container.children('.tree-node').remove();
+            data.forEach(node => {
+                if (container.children('.tree-node[data-id="' + node.id + '"]').length === 0) {
+                    renderTreeNode(node, container, sectionType);
+                }
+            });
+            // Update count badge for root level
+            if (nodeId === '#') {
+                const countEl = document.getElementById(cfg.countId);
+                if (countEl) countEl.textContent = data.length;
+            }
+            setupNodeClickHandlers();
+        })
+        .catch(() => {
+            container.find('.loading-indicator').html('<span class="text-red-500">Error loading. Try again.</span>');
+        });
+}
+
+// ---------- Click handlers ----------
+function setupNodeClickHandlers() {
+    try {
+        $('.expand-icon').off('click.unified').on('click.unified', function(e) {
+            e.stopPropagation();
+            const li = $(this).closest('li');
+            if (li.length) toggleNode(li);
+        });
+        $('.node-content').off('click.unified').on('click.unified', function() {
+            const li = $(this).closest('li');
+            if (li.length) selectNode(li);
+        });
+        $('.node-content').off('dblclick.unified').on('dblclick.unified', function(e) {
+            e.stopPropagation();
+            const li = $(this).closest('li');
+            if (li.length && li.hasClass('has-children')) toggleNode(li);
+        });
+    } catch (_) {}
+}
+
+function toggleNode(li) {
+    const nodeId = li.data('id');
+    const sectionType = li.data('type');
+    const childrenContainer = li.find('> .children-container');
+    const expandIcon = li.find('> .node-content .expand-icon');
+
+    if (li.hasClass('collapsed')) {
+        li.removeClass('collapsed').addClass('expanded');
+        expandIcon.addClass('expanded');
+        childrenContainer.slideDown(200);
+        if (childrenContainer.children('.tree-node').length === 0) {
+            loadTreeNodes(nodeId, childrenContainer, sectionType);
+        }
+        setTimeout(function() {
+            childrenContainer.find('> li:not(.selected):not(.tree-node-highlighted):not(.tree-node-match) > .node-content').css({
+                'background-color': 'white',
+                'color': 'var(--color-text-default, rgb(16, 16, 16))'
+            });
+        }, 250);
+    } else {
+        li.removeClass('expanded').addClass('collapsed');
+        expandIcon.removeClass('expanded');
+        childrenContainer.slideUp(200);
+    }
+}
+
+function selectNode(li, updateUrl) {
+    if (updateUrl === undefined) updateUrl = true;
+    $('.tree-node.selected').removeClass('selected');
+    li.addClass('selected');
+    const nodeId = li.data('id');
+    const sectionType = li.data('type');
+    loadDetails(nodeId, sectionType, updateUrl);
+    ensureNodeVisible(li);
+}
+
+function ensureNodeVisible(li) {
+    li.parents('li.tree-node').each(function() {
+        const parent = $(this);
+        if (parent.hasClass('collapsed')) toggleNode(parent);
+    });
+}
+
+// ---------- Detail loading ----------
+function loadDetails(iri, sectionType, updateUrl) {
+    if (updateUrl === undefined) updateUrl = true;
+    const detailsContainer = document.getElementById('class-details');
+    if (!detailsContainer) return;
+
+    if (updateUrl) {
+        const url = new URL(window.location);
+        url.searchParams.set('node', iri);
+        url.searchParams.set('type', sectionType);
+        history.pushState({ nodeId: iri, type: sectionType }, '', url);
+    }
+
+    detailsContainer.innerHTML = '<div class="flex justify-center items-center h-64"><div class="spinner-border animate-spin inline-block w-8 h-8 border-4 rounded-full text-blue-600" role="status"><span class="sr-only">Loading...</span></div></div>';
+
+    const cfg = SECTIONS[sectionType];
+    let nodeId = iri;
+    if (iri.startsWith('http')) {
+        const parts = iri.split('/').filter(p => p.trim().length > 0);
+        if (parts.length > 0) nodeId = parts[parts.length - 1];
+    }
+
+    // Fetch the server-rendered HTML fragment
+    fetch(cfg.detailsEndpoint + encodeURIComponent(nodeId))
+        .then(response => {
+            if (!response.ok) throw new Error('Could not fetch rendered template');
+            return response.text();
+        })
+        .then(html => {
+            detailsContainer.innerHTML = html;
+        })
+        .catch(() => {
+            // Fallback: fetch JSON and render client-side
+            fetch(cfg.nodeDataEndpoint + encodeURIComponent(nodeId))
+                .then(r => { if (!r.ok) throw new Error('Network error'); return r.json(); })
+                .then(data => {
+                    detailsContainer.innerHTML = '<div class="p-4"><h3 class="text-2xl font-semibold mb-2 text-[--color-primary]">' + (data.label || 'Unknown') + '</h3><p class="text-gray-700">' + (data.definition || '') + '</p></div>';
+                })
+                .catch(() => {
+                    detailsContainer.innerHTML = '<div class="p-4 text-red-500"><h3 class="text-xl font-medium mb-2">Error loading details</h3><p>Unable to load details. Please try again or select a different item.</p></div>';
+                });
+        });
+}
+
+// Alias for cross-type navigation from detail panel links
+function loadClassDetails(iri, updateUrl) {
+    // Determine which section this IRI belongs to by checking DOM first
+    const existingNode = document.querySelector('.tree-node[data-id="' + iri + '"]');
+    if (existingNode) {
+        loadDetails(iri, existingNode.dataset.type, updateUrl);
+    } else {
+        // Default to class type (matches backward-compat from taxonomy tree)
+        loadDetails(iri, 'class', updateUrl);
+    }
+}
+
+// ---------- selectNodeByIri: cross-type navigation ----------
+function selectNodeByIri(iri) {
+    // First check if node already exists in DOM
+    const existingNode = document.querySelector('.tree-node[data-id="' + iri + '"]');
+    if (existingNode) {
+        const li = $(existingNode);
+        selectNode(li, true);
+        existingNode.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        return;
+    }
+
+    // Node not in DOM — try both path APIs in parallel to find it
+    const classPath = fetch(SECTIONS.class.pathEndpoint + encodeURIComponent(extractIdFromIri(iri)))
+        .then(r => r.ok ? r.json() : null).catch(() => null);
+    const propertyPath = fetch(SECTIONS.property.pathEndpoint + encodeURIComponent(extractIdFromIri(iri)))
+        .then(r => r.ok ? r.json() : null).catch(() => null);
+
+    Promise.all([classPath, propertyPath]).then(([classResult, propertyResult]) => {
+        let sectionType = null;
+        let pathData = null;
+        if (classResult && classResult.path && classResult.path.length > 0) {
+            sectionType = 'class';
+            pathData = classResult;
+        } else if (propertyResult && propertyResult.path && propertyResult.path.length > 0) {
+            sectionType = 'property';
+            pathData = propertyResult;
+        }
+
+        if (sectionType && pathData) {
+            // Ensure the section is visible
+            const rootList = document.getElementById(SECTIONS[sectionType].rootListId);
+            if (rootList && rootList.style.display === 'none') {
+                rootList.style.display = '';
+                const header = document.querySelector('.section-header[data-section="' + sectionType + '"]');
+                if (header) header.querySelector('.section-chevron').classList.remove('collapsed');
+            }
+            loadAndSelectNode(iri, sectionType, true);
+        } else {
+            // Last resort: just load details
+            loadDetails(iri, 'class', true);
+        }
+    });
+}
+window.selectNodeByIri = selectNodeByIri;
+
+// ---------- Load and select node (expand path) ----------
+function loadAndSelectNode(nodeId, sectionType, updateUrl) {
+    if (updateUrl === undefined) updateUrl = true;
+    if (isLoadingTree) {
+        setTimeout(() => loadAndSelectNode(nodeId, sectionType, updateUrl), 500);
+        return;
+    }
+
+    const cfg = SECTIONS[sectionType];
+    const rootList = $('#' + cfg.rootListId);
+
+    // Ensure root nodes are loaded
+    if (rootList.children('.tree-node').length === 0) {
+        loadTreeNodes('#', rootList, sectionType);
+    }
+
+    // Check if node already in DOM
+    const node = $('.tree-node[data-id="' + nodeId + '"]');
+    if (node.length > 0) {
+        selectNode(node, updateUrl);
+        node[0].scrollIntoView({ behavior: 'smooth', block: 'center' });
+        return;
+    }
+
+    // Need to find and expand path
+    isLoadingTree = true;
+    const detailsContainer = document.getElementById('class-details');
+    if (detailsContainer) {
+        detailsContainer.innerHTML = '<div class="flex justify-center items-center h-64"><div class="flex flex-col items-center"><div class="spinner-border animate-spin inline-block w-8 h-8 border-4 rounded-full text-blue-600 mb-4" role="status"><span class="sr-only">Loading...</span></div><p class="text-gray-600">Finding and loading node...</p></div></div>';
+    }
+
+    findNodePath(nodeId, sectionType)
+        .then(path => loadNodePath(path, sectionType))
+        .then(() => {
+            const loadedNode = $('.tree-node[data-id="' + nodeId + '"]');
+            if (loadedNode.length > 0) {
+                $('.tree-node.selected').removeClass('selected');
+                loadedNode.addClass('selected');
+                loadedNode[0].scrollIntoView({ block: 'center', behavior: 'smooth' });
+                selectNode(loadedNode, updateUrl);
+            } else {
+                loadDetails(nodeId, sectionType, updateUrl);
+            }
+        })
+        .catch(() => {
+            const finalNode = $('.tree-node[data-id="' + nodeId + '"]');
+            if (finalNode.length > 0) {
+                $('.tree-node.selected').removeClass('selected');
+                finalNode.addClass('selected');
+                finalNode[0].scrollIntoView({ block: 'center', behavior: 'smooth' });
+                selectNode(finalNode, updateUrl);
+            } else {
+                loadDetails(nodeId, sectionType, updateUrl);
+            }
+        })
+        .finally(() => {
+            setTimeout(() => {
+                const finalNode = $('.tree-node[data-id="' + nodeId + '"]');
+                if (finalNode.length > 0 && !finalNode.hasClass('selected')) {
+                    $('.tree-node.selected').removeClass('selected');
+                    finalNode.addClass('selected');
+                }
+                isLoadingTree = false;
+            }, 200);
+        });
+}
+
+async function findNodePath(nodeId, sectionType) {
+    try {
+        const data = await getNodeData(nodeId, sectionType);
+        const path = [];
+        if (data.parents && data.parents.length > 0) {
+            let currentNode = data.parents[0].iri;
+            const parentChain = [currentNode];
+            try {
+                for (let i = 0; i < 5; i++) {
+                    const parentData = await getNodeData(currentNode, sectionType);
+                    if (!parentData.parents || parentData.parents.length === 0) break;
+                    currentNode = parentData.parents[0].iri;
+                    parentChain.unshift(currentNode);
+                }
+            } catch (_) {}
+            path.push(...parentChain);
+        }
+        if (path.length === 0 || path[path.length - 1] !== nodeId) {
+            path.push(nodeId);
+        }
+        return path;
+    } catch (_) {
+        return [nodeId];
+    }
+}
+
+async function loadNodePath(path, sectionType) {
+    if (!path || path.length === 0) return;
+    const cfg = SECTIONS[sectionType];
+    const rootList = $('#' + cfg.rootListId);
+
+    if (rootList.children('.tree-node').length === 0) {
+        await new Promise(resolve => {
+            loadTreeNodes('#', rootList, sectionType);
+            const check = setInterval(() => {
+                if (!rootList.find('.loading-indicator').length) { clearInterval(check); resolve(); }
+            }, 100);
+        });
+    }
+
+    let currentContainer = rootList;
+    for (let i = 0; i < path.length; i++) {
+        const nodeId = path[i];
+        const isLast = (i === path.length - 1);
+        let node = currentContainer.children('.tree-node[data-id="' + nodeId + '"]');
+        if (node.length === 0) node = $('.tree-node[data-id="' + nodeId + '"]');
+
+        if (node.length > 0) {
+            if (!isLast && node.hasClass('collapsed')) toggleNode(node);
+            if (!isLast) {
+                currentContainer = node.find('> .children-container');
+                if (currentContainer.length === 0) {
+                    node.append('<ul class="children-container" style="display:block;"></ul>');
+                    currentContainer = node.find('> .children-container');
+                }
+            }
+        } else {
+            const parentNodeId = i > 0 ? path[i - 1] : '#';
+            await new Promise(resolve => {
+                if (currentContainer.children('.tree-node').length > 0) { resolve(); return; }
+                loadTreeNodes(parentNodeId, currentContainer, sectionType);
+                const check = setInterval(() => {
+                    if (!currentContainer.find('> .loading-indicator').length) {
+                        clearInterval(check);
+                        node = currentContainer.children('.tree-node[data-id="' + nodeId + '"]');
+                        if (node.length === 0) node = $('.tree-node[data-id="' + nodeId + '"]');
+                        if (node.length > 0) {
+                            if (!isLast && node.hasClass('collapsed')) toggleNode(node);
+                            if (!isLast) {
+                                currentContainer = node.find('> .children-container');
+                                if (currentContainer.length === 0) {
+                                    node.append('<ul class="children-container" style="display:block;"></ul>');
+                                    currentContainer = node.find('> .children-container');
+                                }
+                            }
+                        }
+                        resolve();
+                    }
+                }, 100);
+            });
+        }
+    }
+
+    const targetNode = $('.tree-node[data-id="' + path[path.length - 1] + '"]');
+    if (targetNode.length > 0) targetNode[0].scrollIntoView({ block: 'center', behavior: 'smooth' });
+}
+
+// ---------- Tree styles ----------
+function applyTreeStyles() {
+    const style = document.createElement('style');
+    style.textContent = `
+        .section-tree-root, .children-container { list-style-type: none; padding-left: 0; }
+        .children-container { padding-left: 14px; border-left: 1px solid rgba(209, 213, 219, 0.7); margin-left: 6px; }
+        .children-container .tree-node:not(.selected):not(.tree-node-highlighted) > .node-content { background-color: white; color: var(--color-text-default, rgb(16, 16, 16)); }
+        .tree-node { margin: 1px 0; position: relative; }
+        .node-content { display: flex; align-items: center; padding: 2px 6px; border-radius: 3px; cursor: pointer; word-break: break-word; white-space: normal; border-bottom: 1px solid rgba(229, 231, 235, 0.3); line-height: 1.2; }
+        .node-content:hover { background-color: rgba(59, 130, 246, 0.1); }
+        .tree-node.selected > .node-content { background-color: var(--color-primary, rgb(24, 70, 120)) !important; color: white !important; font-weight: 600; }
+        .node-label { flex-grow: 1; }
+        @media (max-width: 768px) {
+            .tree-explorer-container { flex-direction: column; }
+            #tree-container, #detail-container { width: 100%; max-height: none; }
+            #explore-tree { max-height: 400px; }
+        }
+        #explore-tree::-webkit-scrollbar { width: 8px; }
+        #explore-tree::-webkit-scrollbar-track { background: #f1f1f1; border-radius: 4px; }
+        #explore-tree::-webkit-scrollbar-thumb { background: #c1c1c1; border-radius: 4px; }
+        #explore-tree::-webkit-scrollbar-thumb:hover { background: #a8a8a8; }
+        .node-label span.bg-blue-100 { background-color: rgba(229, 231, 235, 0.7); padding: 0 2px; border-radius: 2px; font-weight: bold; color: var(--color-primary, rgb(24, 70, 120)); }
+    `;
+    document.head.appendChild(style);
+}
+
+function applyArrowStyles() {
+    if (document.getElementById('unified-tree-arrow-styles')) return;
+    const s = document.createElement('style');
+    s.id = 'unified-tree-arrow-styles';
+    s.textContent = `
+        .expand-icon { cursor: pointer; width: 20px; height: 20px; display: inline-flex !important; align-items: center !important; justify-content: center; flex-shrink: 0; border-radius: 3px; transition: transform 0.15s ease; color: #6b7280; margin-right: 4px; }
+        .expand-icon:hover { background-color: rgba(107, 114, 128, 0.12); color: #374151; }
+        .expand-icon.expanded { transform: rotate(90deg); }
+        .expand-icon svg { display: block; }
+        .leaf-indicator { width: 20px; height: 20px; display: inline-flex !important; align-items: center !important; justify-content: center; flex-shrink: 0; margin-right: 4px; }
+        .leaf-dot { width: 6px; height: 6px; border-radius: 50%; background-color: #d1d5db; }
+        .tree-node.selected > .node-content .leaf-dot { background-color: rgba(255, 255, 255, 0.6); }
+        .tree-node.selected > .node-content .expand-icon { color: white; }
+    `;
+    document.head.appendChild(s);
+}
+
+// ---------- Expand / Collapse all ----------
+function expandAllNodes() {
+    $('.tree-node.collapsed').each(function() { toggleNode($(this)); });
+}
+
+function collapseAllNodes() {
+    const selectedNodeId = getCurrentSelectedNodeId();
+    let shouldResetUrl = false;
+    if (selectedNodeId) {
+        const selectedNode = $('.tree-node[data-id="' + selectedNodeId + '"]');
+        if (selectedNode.length > 0 && selectedNode.parents('.tree-node').length > 0) shouldResetUrl = true;
+    }
+    $('.tree-node.expanded').each(function() { toggleNode($(this)); });
+    if (shouldResetUrl) resetUrlParameters();
+}
+
+function getCurrentSelectedNodeId() {
+    const url = new URL(window.location);
+    const nodeParam = url.searchParams.get('node');
+    if (nodeParam) return nodeParam;
+    const selectedNode = $('.tree-node.selected');
+    return selectedNode.length > 0 ? selectedNode.data('id') : null;
+}
+
+function resetUrlParameters() {
+    const url = new URL(window.location);
+    if (url.searchParams.has('node')) {
+        url.searchParams.delete('node');
+        url.searchParams.delete('type');
+        window.history.replaceState({}, '', url);
+    }
+}
+
+// ---------- Tree controls ----------
+function setupTreeControls() {
+    const expandBtn = document.getElementById('expand-all-tree');
+    if (expandBtn) expandBtn.addEventListener('click', expandAllNodes);
+    const collapseBtn = document.getElementById('collapse-all-tree');
+    if (collapseBtn) collapseBtn.addEventListener('click', collapseAllNodes);
+}
+
+// ---------- Keyboard navigation ----------
+function setupKeyboardNavigation() {
+    document.addEventListener('keydown', function(event) {
+        if (document.activeElement.tagName === 'INPUT' || document.activeElement.tagName === 'TEXTAREA') return;
+        const selectedNode = document.querySelector('.tree-node.selected');
+        if (!selectedNode) return;
+
+        if (event.key === ' ') {
+            event.preventDefault();
+            if (selectedNode.classList.contains('has-children')) {
+                const icon = selectedNode.querySelector('.expand-icon');
+                if (icon) icon.click();
+            }
+        } else if (event.key === 'ArrowRight') {
+            event.preventDefault();
+            if (selectedNode.classList.contains('has-children') && selectedNode.classList.contains('collapsed')) {
+                const icon = selectedNode.querySelector('.expand-icon');
+                if (icon) icon.click();
+            }
+        } else if (event.key === 'ArrowLeft') {
+            event.preventDefault();
+            if (selectedNode.classList.contains('has-children') && selectedNode.classList.contains('expanded')) {
+                const icon = selectedNode.querySelector('.expand-icon');
+                if (icon) icon.click();
+            }
+        } else if (event.key === 'ArrowDown') {
+            event.preventDefault();
+            const visible = Array.from(document.querySelectorAll('.tree-node')).filter(n => window.getComputedStyle(n).display !== 'none');
+            const idx = visible.indexOf(selectedNode);
+            if (idx < visible.length - 1) {
+                const nc = visible[idx + 1].querySelector('.node-content');
+                if (nc) nc.click();
+            }
+        } else if (event.key === 'ArrowUp') {
+            event.preventDefault();
+            const visible = Array.from(document.querySelectorAll('.tree-node')).filter(n => window.getComputedStyle(n).display !== 'none');
+            const idx = visible.indexOf(selectedNode);
+            if (idx > 0) {
+                const nc = visible[idx - 1].querySelector('.node-content');
+                if (nc) nc.click();
+            }
+        }
+    });
+}
+
+// ---------- History navigation ----------
+function setupHistoryNavigation() {
+    // Handle initial URL params
+    const urlParams = new URLSearchParams(window.location.search);
+    const nodeId = urlParams.get('node');
+    const nodeType = urlParams.get('type') || 'class';
+
+    if (nodeId) {
+        // Ensure the right section is visible
+        const cfg = SECTIONS[nodeType];
+        if (cfg) {
+            const rootList = document.getElementById(cfg.rootListId);
+            if (rootList && rootList.style.display === 'none') {
+                rootList.style.display = '';
+                const header = document.querySelector('.section-header[data-section="' + nodeType + '"]');
+                if (header) header.querySelector('.section-chevron').classList.remove('collapsed');
+            }
+        }
+        loadAndSelectNode(nodeId, nodeType, false);
+    }
+
+    // Listen for back/forward
+    window.addEventListener('popstate', function(event) {
+        if (event.state && event.state.nodeId) {
+            const type = event.state.type || 'class';
+            loadAndSelectNode(event.state.nodeId, type, false);
+        } else {
+            const params = new URLSearchParams(window.location.search);
+            const nid = params.get('node');
+            const ntype = params.get('type') || 'class';
+            if (nid) {
+                loadAndSelectNode(nid, ntype, false);
+            } else {
+                $('.tree-node.selected').removeClass('selected');
+                const dc = document.getElementById('class-details');
+                if (dc) {
+                    dc.innerHTML = '<div class="flex items-center justify-center h-full text-gray-500"><div class="text-center"><svg class="w-16 h-16 mx-auto text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" /></svg><h3 class="mt-2 text-xl font-medium">Select an item</h3><p class="mt-1">Choose a class or property from the tree to view its details</p></div></div>';
+                }
+            }
+        }
+    });
+}
+
+// ---------- Search ----------
+function setupSearch() {
+    const input = document.getElementById('explore-search-input');
+    const button = document.getElementById('explore-search-button');
+    if (!input || !button) return;
+
+    function doSearch() {
+        const query = input.value;
+        if (query && query.length >= 2) {
+            resetTreeSearch();
+            searchUnified(query);
+        } else if (query.length > 0 && query.length < 2) {
+            alert('Please enter at least 2 characters for search');
+        } else {
+            resetTreeSearch();
+        }
+    }
+
+    button.addEventListener('click', doSearch);
+    input.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter') { e.preventDefault(); doSearch(); }
+        if (e.key === 'Escape') { input.value = ''; resetTreeSearch(); }
+    });
+
+    // Wire up the inline clear (X) button
+    const clearBtn = document.getElementById('explore-search-clear');
+    if (clearBtn) {
+        clearBtn.addEventListener('click', function() {
+            resetTreeSearch();
+            input.focus();
+        });
+    }
+}
+
+function searchUnified(query) {
+    if (!query || query.length < 2) return;
+
+    // Show loading
+    const treeEl = document.getElementById('explore-tree');
+    const classSec = document.getElementById('class-section');
+    const propSec = document.getElementById('property-section');
+
+    // Fire both searches in parallel
+    const classSearch = fetch(SECTIONS.class.searchEndpoint + '?query=' + encodeURIComponent(query))
+        .then(r => r.json()).catch(() => ({ matches: [], tree: {} }));
+    const propSearch = fetch(SECTIONS.property.searchEndpoint + '?query=' + encodeURIComponent(query))
+        .then(r => r.json()).catch(() => ({ matches: [], tree: {} }));
+
+    Promise.all([classSearch, propSearch]).then(([classData, propData]) => {
+        const classMatches = classData.matches || [];
+        const propMatches = propData.matches || [];
+        const totalMatches = classMatches.length + propMatches.length;
+
+        // Add filter controls
+        addFilterModeControls(totalMatches, query, classMatches.length, propMatches.length);
+
+        // Render class section
+        const classRoot = document.getElementById(SECTIONS.class.rootListId);
+        classRoot.innerHTML = '';
+        if (classMatches.length > 0 && classData.tree) {
+            renderFilteredTree(classData.tree, classRoot, 'class', query);
+            classSec.style.display = '';
+            // Ensure section is expanded
+            const classChevron = classSec.querySelector('.section-chevron');
+            if (classChevron) classChevron.classList.remove('collapsed');
+            classRoot.style.display = '';
+        } else {
+            // Collapse empty class section
+            classRoot.style.display = 'none';
+            const classChevron = classSec.querySelector('.section-chevron');
+            if (classChevron) classChevron.classList.add('collapsed');
+        }
+
+        // Render property section
+        const propRoot = document.getElementById(SECTIONS.property.rootListId);
+        propRoot.innerHTML = '';
+        if (propMatches.length > 0 && propData.tree) {
+            renderFilteredTree(propData.tree, propRoot, 'property', query);
+            propSec.style.display = '';
+            const propChevron = propSec.querySelector('.section-chevron');
+            if (propChevron) propChevron.classList.remove('collapsed');
+            propRoot.style.display = '';
+        } else {
+            propRoot.style.display = 'none';
+            const propChevron = propSec.querySelector('.section-chevron');
+            if (propChevron) propChevron.classList.add('collapsed');
+        }
+
+        // Update count badges
+        document.getElementById('class-count').textContent = classMatches.length || '';
+        document.getElementById('property-count').textContent = propMatches.length || '';
+
+        setupNodeClickHandlers();
+
+        // Highlight matches
+        document.querySelectorAll('.tree-node-match').forEach(node => {
+            node.classList.add('tree-node-highlighted');
+            const label = node.querySelector('.node-label');
+            if (label) label.innerHTML = highlightText(label.textContent, query);
+        });
+
+        // Select first match
+        const firstMatch = document.querySelector('.tree-node-highlighted');
+        if (firstMatch) {
+            const li = $(firstMatch);
+            const sectionType = firstMatch.dataset.type;
+            loadDetails(firstMatch.dataset.id, sectionType, true);
+            li.addClass('selected');
+            firstMatch.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+
+        if (totalMatches === 0) {
+            // No results — restore trees
+            clearFilterMode();
+        }
+    });
+}
+
+function renderFilteredTree(treeData, container, sectionType, query) {
+    if (!treeData || !treeData.root_nodes) return;
+    treeData.root_nodes.forEach(nodeId => {
+        renderFilteredNode(nodeId, treeData, container, sectionType, true);
+    });
+}
+
+function renderFilteredNode(nodeId, treeData, container, sectionType, isExpanded) {
+    const node = treeData.nodes[nodeId];
+    if (!node) return;
+    const hasChildren = node.children && node.children.length > 0;
+    const nodeClass = hasChildren ? (isExpanded ? 'has-children expanded' : 'has-children collapsed') : '';
+    const isMatch = node.is_match ? 'tree-node-match' : '';
+    const expandIcon = hasChildren
+        ? '<span class="expand-icon' + (isExpanded ? ' expanded' : '') + '"><svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 3 11 8 6 13"></polyline></svg></span>'
+        : '<span class="leaf-indicator"><span class="leaf-dot"></span></span>';
+
+    const li = document.createElement('li');
+    li.className = 'tree-node ' + nodeClass + ' ' + isMatch;
+    li.dataset.id = node.id;
+    li.dataset.type = sectionType;
+    li.innerHTML = '<div class="node-content">' + expandIcon + '<span class="node-label">' + node.label + '</span></div>' +
+        (hasChildren ? '<ul class="children-container" style="display:' + (isExpanded ? 'block' : 'none') + ';"></ul>' : '');
+    container.appendChild(li);
+
+    if (hasChildren && isExpanded) {
+        const childrenContainer = li.querySelector('.children-container');
+        node.children.forEach(childId => {
+            const childNode = treeData.nodes[childId];
+            const shouldExpand = childNode && (childNode.is_match || hasMatchDescendant(childId, treeData));
+            renderFilteredNode(childId, treeData, childrenContainer, sectionType, shouldExpand);
+        });
+    }
+}
+
+function hasMatchDescendant(nodeId, treeData) {
+    const node = treeData.nodes[nodeId];
+    if (!node) return false;
+    if (node.is_match) return true;
+    if (node.children) {
+        for (const childId of node.children) {
+            if (hasMatchDescendant(childId, treeData)) return true;
+        }
+    }
+    return false;
+}
+
+function addFilterModeControls(totalCount, query, classCount, propCount) {
+    // Show the inline clear (X) button inside the search input
+    const clearBtn = document.getElementById('explore-search-clear');
+    if (clearBtn) clearBtn.style.display = 'flex';
+
+    // Build match-count text
+    let detail = totalCount + ' match' + (totalCount !== 1 ? 'es' : '');
+    if (classCount > 0 && propCount > 0) {
+        detail += ' (' + classCount + ' class' + (classCount !== 1 ? 'es' : '') + ', ' + propCount + ' propert' + (propCount !== 1 ? 'ies' : 'y') + ')';
+    } else if (classCount > 0) {
+        detail += ' in classes';
+    } else if (propCount > 0) {
+        detail += ' in properties';
+    }
+
+    // Show the match-count line below the search input
+    const countEl = document.getElementById('search-match-count');
+    if (countEl) {
+        countEl.textContent = detail;
+        countEl.style.display = '';
+    }
+
+    // Mark filter as active (used by resetTreeSearch to detect filter state)
+    document.getElementById('explore-search-input').dataset.filtering = 'true';
+
+    addFilterModeStyles();
+}
+
+function clearFilterMode() {
+    // Hide inline clear button and match count
+    const clearBtn = document.getElementById('explore-search-clear');
+    if (clearBtn) clearBtn.style.display = 'none';
+    const countEl = document.getElementById('search-match-count');
+    if (countEl) { countEl.textContent = ''; countEl.style.display = 'none'; }
+
+    // Clear the search input text and filtering flag
+    const input = document.getElementById('explore-search-input');
+    if (input) { input.value = ''; delete input.dataset.filtering; }
+
+    // Restore both sections
+    ['class', 'property'].forEach(sectionType => {
+        const cfg = SECTIONS[sectionType];
+        const rootList = document.getElementById(cfg.rootListId);
+        rootList.innerHTML = '';
+        rootList.style.display = '';
+        const section = document.getElementById(cfg.sectionId);
+        section.style.display = '';
+        const chevron = section.querySelector('.section-chevron');
+        if (chevron) chevron.classList.remove('collapsed');
+        loadTreeNodes('#', $(rootList), sectionType);
+    });
+
+    // Reset detail panel
+    const dc = document.getElementById('class-details');
+    if (dc) {
+        dc.innerHTML = '<div class="flex items-center justify-center h-full text-gray-500"><div class="text-center"><svg class="w-16 h-16 mx-auto text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" /></svg><h3 class="mt-2 text-xl font-medium">Select an item</h3><p class="mt-1">Choose a class or property from the tree to view its details</p></div></div>';
+    }
+}
+
+function resetTreeSearch() {
+    const input = document.getElementById('explore-search-input');
+    const isFilterMode = input && input.dataset.filtering === 'true';
+    if (isFilterMode) {
+        clearFilterMode();
+    } else {
+        document.querySelectorAll('.tree-node-highlighted').forEach(node => {
+            node.classList.remove('tree-node-highlighted');
+            const label = node.querySelector('.node-label');
+            if (label) label.textContent = label.textContent;
+        });
+    }
+}
+
+function addFilterModeStyles() {
+    if (document.getElementById('filter-mode-styles')) return;
+    const style = document.createElement('style');
+    style.id = 'filter-mode-styles';
+    style.textContent = '.tree-node-highlighted>.node-content,.tree-node-match>.node-content{background-color:var(--color-primary,rgb(24,70,120))!important;color:white!important;border-left-color:rgba(255,255,255,0.8)!important}.tree-node-match>.node-content{font-weight:500}';
+    document.head.appendChild(style);
+}
+
+function highlightText(text, query) {
+    const regex = new RegExp('(' + escapeRegEx(query) + ')', 'gi');
+    return text.replace(regex, '<span class="bg-blue-100">$1</span>');
+}
+
+function escapeRegEx(string) {
+    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+// ---------- Main initialization ----------
+function initializeUnifiedTree() {
+    if (typeof $ === 'undefined') {
+        const treeEl = document.getElementById('explore-tree');
+        if (treeEl) treeEl.innerHTML = '<div class="p-4 text-yellow-800 bg-yellow-100 rounded"><h3 class="font-medium">Unable to load tree</h3><p>JavaScript libraries needed for the tree are not available.</p></div>';
+        return;
+    }
+
+    applyTreeStyles();
+    applyArrowStyles();
+    setupSectionHeaders();
+
+    // Load both sections eagerly
+    loadTreeNodes('#', $('#class-tree-root'), 'class');
+    loadTreeNodes('#', $('#property-tree-root'), 'property');
+
+    setupNodeClickHandlers();
+    setupTreeControls();
+    setupKeyboardNavigation();
+    setupHistoryNavigation();
+    setupSearch();
+}

--- a/folio_api/templates/jinja2/components/class_details.html
+++ b/folio_api/templates/jinja2/components/class_details.html
@@ -75,7 +75,7 @@
     <!-- Parents section -->
     {% if class_data.parents %}
     <section class="card animate-fade-in">
-        <h4 class="text-lg font-medium text-[--color-primary] mb-3">Parent Classes</h4>
+        <h4 class="text-lg font-medium text-[--color-primary] mb-3">Parent(s)</h4>
         <div class="max-h-[200px] overflow-y-auto pr-1">
             <ul class="space-y-2">
                 {% for parent in class_data.parents %}
@@ -107,7 +107,7 @@
     {% if class_data.children %}
     <section class="card animate-fade-in">
         <h4 class="text-lg font-medium text-[--color-primary] mb-3 flex items-center">
-            Child Classes 
+            Children
             <span class="ml-2 px-1.5 py-0.5 text-xs font-semibold bg-blue-100 text-blue-800 rounded-full">
                 {{ class_data.children|length }}
             </span>

--- a/folio_api/templates/jinja2/components/class_details.html
+++ b/folio_api/templates/jinja2/components/class_details.html
@@ -420,6 +420,49 @@
         </div>
     </section>
     {% endif %}
+
+    <!-- Related Object Properties -->
+    {% if domain_properties or range_properties %}
+    <section class="card animate-fade-in xl:col-span-2">
+        <h4 class="text-lg font-medium text-[--color-primary] mb-3 flex items-center">
+            <svg class="w-4 h-4 mr-2 text-teal-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+            </svg>
+            Related Object Properties
+        </h4>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {% if domain_properties %}
+            <div class="bg-teal-50 rounded-lg p-3">
+                <p class="text-gray-700 text-xs font-medium uppercase tracking-wide mb-2">Properties with this class as Domain</p>
+                <div class="max-h-[200px] overflow-y-auto">
+                    <ul class="space-y-1">
+                        {# INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged #}
+                        {% for prop in domain_properties %}
+                        <li>
+                            <a href="/{{ prop.iri }}/html" class="text-teal-700 hover:text-teal-900 hover:underline text-sm">{{ prop.label|strip_folio_prefix }}</a>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+            {% endif %}
+            {% if range_properties %}
+            <div class="bg-orange-50 rounded-lg p-3">
+                <p class="text-gray-700 text-xs font-medium uppercase tracking-wide mb-2">Properties with this class as Range</p>
+                <div class="max-h-[200px] overflow-y-auto">
+                    <ul class="space-y-1">
+                        {% for prop in range_properties %}
+                        <li>
+                            <a href="/{{ prop.iri }}/html" class="text-orange-700 hover:text-orange-900 hover:underline text-sm">{{ prop.label|strip_folio_prefix }}</a>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+            {% endif %}
+        </div>
+    </section>
+    {% endif %}
 </div>
 {% else %}
 <div class="flex items-center justify-center h-full text-gray-500">

--- a/folio_api/templates/jinja2/components/class_details.html
+++ b/folio_api/templates/jinja2/components/class_details.html
@@ -151,12 +151,12 @@
         <div class="max-h-[200px] overflow-y-auto pr-1">
             <div class="grid grid-cols-1 gap-3">
                 {% for language, translation in class_data.translations.items() %}
-                <div class="bg-gray-50 rounded-md p-3 border-l-2 border-blue-300">
-                    <div class="flex items-center mb-1.5">
+                <div class="bg-gray-50 rounded-md px-3 py-1.5 border-l-2 border-blue-300">
+                    <div class="flex items-center">
                         {% set language_lower = language|lower %}
                         {% set language_code = language_lower[:2] %}
                         {% set language_flags = {
-                            "en": "🇬🇧", "en-gb": "🇬🇧", "en-us": "🇺🇸", "en-ca": "🇨🇦", "en-au": "🇦🇺", "en-nz": "🇳🇿", 
+                            "en": "🇬🇧", "en-gb": "🇬🇧", "en-us": "🇺🇸", "en-ca": "🇨🇦", "en-au": "🇦🇺", "en-nz": "🇳🇿",
                             "de": "🇩🇪", "de-de": "🇩🇪", "de-at": "🇦🇹", "de-ch": "🇨🇭",
                             "fr": "🇫🇷", "fr-fr": "🇫🇷", "fr-ca": "🇨🇦", "fr-ch": "🇨🇭", "fr-be": "🇧🇪",
                             "es": "🇪🇸", "es-es": "🇪🇸", "es-mx": "🇲🇽", "es-ar": "🇦🇷", "es-co": "🇨🇴",
@@ -170,13 +170,13 @@
                             "ko": "🇰🇷", "ko-kr": "🇰🇷",
                             "hi": "🇮🇳", "hi-in": "🇮🇳",
                             "ar": "🇸🇦", "ar-sa": "🇸🇦", "ar-eg": "🇪🇬", "ar-dz": "🇩🇿",
-                            "he": "🇮🇱", "he-il": "🇮🇱", 
+                            "he": "🇮🇱", "he-il": "🇮🇱",
                             "th": "🇹🇭", "vi": "🇻🇳"
                         } %}
                         <span class="text-lg mr-2">{{ language_flags.get(language_lower, language_flags.get(language_code, "🌐")) }}</span>
-                        <p class="text-gray-700 font-medium">{{ language }}</p>
+                        <span class="text-gray-500 font-mono text-sm w-12 flex-shrink-0">{{ language }}</span>
+                        <span class="text-gray-800 italic ml-2">{{ translation }}</span>
                     </div>
-                    <p class="text-gray-800 italic">{{ translation }}</p>
                 </div>
                 {% endfor %}
             </div>

--- a/folio_api/templates/jinja2/components/header.html
+++ b/folio_api/templates/jinja2/components/header.html
@@ -6,15 +6,17 @@
                 <p class="text-xl text-white opacity-80 hidden md:block">{% block header_subtitle %}Exploring the Federated Open Legal Information Ontology{% endblock %}</p>
             </div>
             <div class="hidden md:block header-buttons">
-                <a href="https://openlegalstandard.org/" target="_blank" class="inline-block bg-white text-[--color-primary] font-semibold px-4 py-2 rounded hover:bg-opacity-90 transition-colors duration-200 mr-2">FOLIO Website</a>
+                <a href="/taxonomy/browse" class="inline-block bg-white text-[--color-primary] font-semibold px-4 py-2 rounded hover:bg-opacity-90 transition-colors duration-200 mr-2">Classes</a>
+                <a href="/properties/browse" class="inline-block bg-white text-[--color-primary] font-semibold px-4 py-2 rounded hover:bg-opacity-90 transition-colors duration-200 mr-2">Properties</a>
+                <a href="https://openlegalstandard.org/" target="_blank" class="inline-block bg-transparent text-white border border-white font-semibold px-4 py-2 rounded hover:bg-white hover:bg-opacity-10 transition-colors duration-200 mr-2">FOLIO Website</a>
                 <a href="https://openlegalstandard.org/education/" target="_blank" class="inline-block bg-transparent text-white border border-white font-semibold px-4 py-2 rounded hover:bg-white hover:bg-opacity-10 transition-colors duration-200">Learn More</a>
             </div>
         </div>
         
         <div class="mt-6 max-w-3xl">
             <div class="relative">
-                <label for="search-input" class="sr-only">Search for FOLIO classes</label>
-                <input id="search-input" type="text" placeholder="Search for FOLIO classes..." class="w-full p-3 rounded-lg border border-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-opacity-50 text-gray-800">
+                <label for="search-input" class="sr-only">Search for FOLIO classes and properties</label>
+                <input id="search-input" type="text" placeholder="Search for FOLIO classes and properties..." class="w-full p-3 rounded-lg border border-white focus:outline-none focus:ring-2 focus:ring-white focus:ring-opacity-50 text-gray-800">
                 <div id="search-results" class="absolute top-14 left-0 w-full bg-white dark:bg-[--color-bg-page] shadow-lg rounded-lg overflow-hidden mt-2 border border-[--color-secondary] border-opacity-20"></div>
                 
                 <!-- Progressive enhancement: Alternative search for non-JS browsers -->

--- a/folio_api/templates/jinja2/components/header.html
+++ b/folio_api/templates/jinja2/components/header.html
@@ -6,9 +6,7 @@
                 <p class="text-xl text-white opacity-80 hidden md:block">{% block header_subtitle %}Exploring the Federated Open Legal Information Ontology{% endblock %}</p>
             </div>
             <div class="hidden md:block header-buttons">
-                <a href="/explore/tree" class="inline-block bg-white text-[--color-primary] font-semibold px-4 py-2 rounded hover:bg-opacity-90 transition-colors duration-200 mr-2">Explore</a>
-                <a href="/taxonomy/browse" class="inline-block bg-white text-[--color-primary] font-semibold px-4 py-2 rounded hover:bg-opacity-90 transition-colors duration-200 mr-2">Classes</a>
-                <a href="/properties/browse" class="inline-block bg-white text-[--color-primary] font-semibold px-4 py-2 rounded hover:bg-opacity-90 transition-colors duration-200 mr-2">Properties</a>
+                <a href="/explore/tree" class="inline-block bg-white text-[--color-primary] font-semibold px-4 py-2 rounded hover:bg-opacity-90 transition-colors duration-200 mr-2">Browse</a>
                 <a href="https://openlegalstandard.org/" target="_blank" class="inline-block bg-transparent text-white border border-white font-semibold px-4 py-2 rounded hover:bg-white hover:bg-opacity-10 transition-colors duration-200 mr-2">FOLIO Website</a>
                 <a href="https://openlegalstandard.org/education/" target="_blank" class="inline-block bg-transparent text-white border border-white font-semibold px-4 py-2 rounded hover:bg-white hover:bg-opacity-10 transition-colors duration-200">Learn More</a>
             </div>

--- a/folio_api/templates/jinja2/components/header.html
+++ b/folio_api/templates/jinja2/components/header.html
@@ -6,6 +6,7 @@
                 <p class="text-xl text-white opacity-80 hidden md:block">{% block header_subtitle %}Exploring the Federated Open Legal Information Ontology{% endblock %}</p>
             </div>
             <div class="hidden md:block header-buttons">
+                <a href="/explore/tree" class="inline-block bg-white text-[--color-primary] font-semibold px-4 py-2 rounded hover:bg-opacity-90 transition-colors duration-200 mr-2">Explore</a>
                 <a href="/taxonomy/browse" class="inline-block bg-white text-[--color-primary] font-semibold px-4 py-2 rounded hover:bg-opacity-90 transition-colors duration-200 mr-2">Classes</a>
                 <a href="/properties/browse" class="inline-block bg-white text-[--color-primary] font-semibold px-4 py-2 rounded hover:bg-opacity-90 transition-colors duration-200 mr-2">Properties</a>
                 <a href="https://openlegalstandard.org/" target="_blank" class="inline-block bg-transparent text-white border border-white font-semibold px-4 py-2 rounded hover:bg-white hover:bg-opacity-10 transition-colors duration-200 mr-2">FOLIO Website</a>

--- a/folio_api/templates/jinja2/components/property_details.html
+++ b/folio_api/templates/jinja2/components/property_details.html
@@ -1,0 +1,227 @@
+{% if prop_data %}
+<section class="card animate-fade-in mb-6 border-t-4 border-[--color-primary]">
+    <div class="flex justify-between items-start">
+        <div>
+            <div class="flex items-center mb-2">
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800 mr-2">Property</span>
+                {# INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged #}
+                <h3 class="text-2xl font-semibold text-[--color-primary]">{{ prop_data.label|strip_folio_prefix }}</h3>
+            </div>
+            <div class="flex flex-col sm:flex-row sm:items-center text-gray-500 text-sm mb-4">
+                <span class="font-medium mb-1 sm:mb-0 sm:mr-1.5 flex-shrink-0">IRI:</span>
+                <div class="overflow-hidden flex-1 min-w-0 mb-1 sm:mb-0 sm:mr-2">
+                    <span class="font-mono break-all block w-full" id="iri-value" title="{{ prop_data.iri }}">{{ prop_data.iri }}</span>
+                </div>
+                <button onclick="navigator.clipboard.writeText('{{ prop_data.iri }}')" 
+                        class="self-end sm:self-auto sm:ml-auto py-1 px-2 rounded text-blue-600 hover:bg-blue-50 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-blue-500 flex-shrink-0" 
+                        aria-label="Copy IRI to clipboard">
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+                    </svg>
+                </button>
+            </div>
+        </div>
+    </div>
+    
+    <div class="prose max-w-none mt-2 bg-gray-50 p-3 rounded-md border-l-4 border-blue-200">
+        <p class="text-gray-800">{{ prop_data.definition }}</p>
+    </div>
+</section>
+
+<div class="grid grid-cols-1 xl:grid-cols-2 gap-6 w-full" style="width: 100%; max-width: 100%;" id="detail-grid">
+    <!-- Labels section -->
+    {% if prop_data.preferred_label or prop_data.alternative_labels %}
+    <section class="card animate-fade-in">
+        <h4 class="text-lg font-medium text-[--color-primary] mb-3 flex items-center">
+            <svg class="w-4 h-4 mr-2 text-purple-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z" />
+            </svg>
+            Labels & Synonyms
+        </h4>
+        <div class="max-h-[200px] overflow-y-auto pr-1">
+            <div class="bg-purple-50 rounded-lg p-4 border-l-3 border-purple-200">
+                {% if prop_data.preferred_label %}
+                <div class="mb-3">
+                    <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-1 block">Preferred Label</span>
+                    <span class="text-gray-800 font-medium text-lg block">{{ prop_data.preferred_label|strip_folio_prefix }}</span>
+                </div>
+                {% endif %}
+                {% if prop_data.alternative_labels %}
+                <div>
+                    <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-2 block">Alternative Labels</span>
+                    <div class="flex flex-wrap gap-1">
+                        {% for label in prop_data.alternative_labels %}
+                        {# INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged #}
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium bg-purple-100 text-purple-800">{{ label|strip_folio_prefix }}</span>
+                        {% endfor %}
+                    </div>
+                </div>
+                {% endif %}
+            </div>
+        </div>
+    </section>
+    {% endif %}
+    
+    <!-- Parent Properties -->
+    {% if prop_data.parents %}
+    <section class="card animate-fade-in">
+        <h4 class="text-lg font-medium text-[--color-primary] mb-3">Parent Properties</h4>
+        <div class="max-h-[200px] overflow-y-auto pr-1">
+            <ul class="space-y-2">
+                {% for parent in prop_data.parents %}
+                <li class="group p-1.5 -ml-1.5 rounded-md hover:bg-blue-50 transition-colors duration-150">
+                    <div class="flex items-start">
+                        <svg class="w-4 h-4 mt-1 mr-2 text-blue-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 11l5-5m0 0l5 5m-5-5v12" />
+                        </svg>
+                        <div>
+                            <a href="#" class="font-medium text-blue-600 hover:text-blue-800 transition-colors duration-150 group-hover:underline" onclick="selectNodeByIri('{{ parent.iri }}'); return false;">{{ parent.label|strip_folio_prefix }}</a>
+                            <p class="text-sm text-gray-600 mt-0.5 line-clamp-2">{{ parent.definition }}</p>
+                        </div>
+                    </div>
+                </li>
+                {% endfor %}
+            </ul>
+        </div>
+    </section>
+    {% endif %}
+    
+    <!-- Child Properties -->
+    {% if prop_data.children %}
+    <section class="card animate-fade-in">
+        <h4 class="text-lg font-medium text-[--color-primary] mb-3 flex items-center">
+            Child Properties
+            <span class="ml-2 px-1.5 py-0.5 text-xs font-semibold bg-blue-100 text-blue-800 rounded-full">{{ prop_data.children|length }}</span>
+        </h4>
+        <div class="max-h-[300px] overflow-y-auto pr-1">
+            <ul class="space-y-2">
+                {% for child in prop_data.children %}
+                <li class="group p-1.5 -ml-1.5 rounded-md hover:bg-blue-50 transition-colors duration-150">
+                    <div class="flex items-start">
+                        <svg class="w-4 h-4 mt-1 mr-2 text-green-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 13l-5 5m0 0l-5-5m5 5V6" />
+                        </svg>
+                        <div>
+                            <a href="#" class="font-medium text-blue-600 hover:text-blue-800 transition-colors duration-150 group-hover:underline" onclick="selectNodeByIri('{{ child.iri }}'); return false;">{{ child.label|strip_folio_prefix }}</a>
+                            <p class="text-sm text-gray-600 mt-0.5 line-clamp-2">{{ child.definition }}</p>
+                        </div>
+                    </div>
+                </li>
+                {% endfor %}
+            </ul>
+        </div>
+    </section>
+    {% endif %}
+    
+    <!-- Inverse Property -->
+    {% if prop_data.inverse %}
+    <section class="card animate-fade-in">
+        <h4 class="text-lg font-medium text-[--color-primary] mb-3 flex items-center">
+            <svg class="w-4 h-4 mr-2 text-purple-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+            </svg>
+            Inverse Property
+        </h4>
+        <div class="bg-purple-50 rounded-lg p-4 border-l-3 border-purple-200">
+            <a href="#" class="font-medium text-purple-700 hover:text-purple-900 hover:underline" onclick="selectNodeByIri('{{ prop_data.inverse.iri }}'); return false;">{{ prop_data.inverse.label|strip_folio_prefix }}</a>
+        </div>
+    </section>
+    {% endif %}
+    
+    <!-- Domain Classes -->
+    {% if prop_data.domain_classes %}
+    <section class="card animate-fade-in">
+        <h4 class="text-lg font-medium text-[--color-primary] mb-3 flex items-center">
+            <svg class="w-4 h-4 mr-2 text-teal-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+            Domain (Subject Classes)
+            <span class="ml-2 px-1.5 py-0.5 text-xs font-semibold bg-teal-100 text-teal-800 rounded-full">{{ prop_data.domain_classes|length }}</span>
+        </h4>
+        <div class="max-h-[200px] overflow-y-auto pr-1">
+            <ul class="space-y-2">
+                {% for cls in prop_data.domain_classes %}
+                <li class="group p-1.5 -ml-1.5 rounded-md hover:bg-teal-50 transition-colors duration-150">
+                    <div class="flex items-start">
+                        <span class="text-teal-500 mr-2 mt-1">&bull;</span>
+                        <div>
+                            <a href="{{ cls.iri }}/html" class="font-medium text-teal-700 hover:text-teal-900 transition-colors duration-150 group-hover:underline">{{ cls.label }}</a>
+                            {% if cls.definition %}
+                            <p class="text-sm text-gray-600 mt-0.5 line-clamp-2">{{ cls.definition }}</p>
+                            {% endif %}
+                        </div>
+                    </div>
+                </li>
+                {% endfor %}
+            </ul>
+        </div>
+    </section>
+    {% endif %}
+    
+    <!-- Range Classes -->
+    {% if prop_data.range_classes %}
+    <section class="card animate-fade-in">
+        <h4 class="text-lg font-medium text-[--color-primary] mb-3 flex items-center">
+            <svg class="w-4 h-4 mr-2 text-orange-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+            Range (Object Classes)
+            <span class="ml-2 px-1.5 py-0.5 text-xs font-semibold bg-orange-100 text-orange-800 rounded-full">{{ prop_data.range_classes|length }}</span>
+        </h4>
+        <div class="max-h-[200px] overflow-y-auto pr-1">
+            <ul class="space-y-2">
+                {% for cls in prop_data.range_classes %}
+                <li class="group p-1.5 -ml-1.5 rounded-md hover:bg-orange-50 transition-colors duration-150">
+                    <div class="flex items-start">
+                        <span class="text-orange-500 mr-2 mt-1">&bull;</span>
+                        <div>
+                            <a href="{{ cls.iri }}/html" class="font-medium text-orange-700 hover:text-orange-900 transition-colors duration-150 group-hover:underline">{{ cls.label }}</a>
+                            {% if cls.definition %}
+                            <p class="text-sm text-gray-600 mt-0.5 line-clamp-2">{{ cls.definition }}</p>
+                            {% endif %}
+                        </div>
+                    </div>
+                </li>
+                {% endfor %}
+            </ul>
+        </div>
+    </section>
+    {% endif %}
+    
+    <!-- Examples -->
+    {% if prop_data.examples %}
+    <section class="card animate-fade-in">
+        <h4 class="text-lg font-medium text-[--color-primary] mb-3 flex items-center">
+            <svg class="w-4 h-4 mr-2 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 20l4-16m2 16l4-16M6 9h14M4 15h14" />
+            </svg>
+            Examples
+        </h4>
+        <div class="max-h-[200px] overflow-y-auto pr-1">
+            <div class="bg-green-50 border border-green-100 rounded-md p-2">
+                <ul class="space-y-2.5">
+                    {% for example in prop_data.examples %}
+                    <li class="flex items-start">
+                        <svg class="w-5 h-5 mr-2 text-green-500 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                        <span class="text-gray-800">{{ example }}</span>
+                    </li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
+    </section>
+    {% endif %}
+</div>
+{% else %}
+<div class="flex items-center justify-center h-full text-gray-500">
+    <div class="text-center">
+        <svg class="w-16 h-16 mx-auto text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+        </svg>
+        <h3 class="mt-2 text-xl font-medium">Select a property</h3>
+        <p class="mt-1">Choose a property from the tree to view its details</p>
+    </div>
+</div>
+{% endif %}

--- a/folio_api/templates/jinja2/components/property_details.html
+++ b/folio_api/templates/jinja2/components/property_details.html
@@ -3,9 +3,9 @@
     <div class="flex justify-between items-start">
         <div>
             <div class="flex items-center mb-2">
-                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800 mr-2">Property</span>
                 {# INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged #}
                 <h3 class="text-2xl font-semibold text-[--color-primary]">{{ prop_data.label|strip_folio_prefix }}</h3>
+                <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800 ml-3">Verb (Property)</span>
             </div>
             <div class="flex flex-col sm:flex-row sm:items-center text-gray-500 text-sm mb-4">
                 <span class="font-medium mb-1 sm:mb-0 sm:mr-1.5 flex-shrink-0">IRI:</span>

--- a/folio_api/templates/jinja2/explore/tree.html
+++ b/folio_api/templates/jinja2/explore/tree.html
@@ -166,7 +166,7 @@
                     </button>
                 </div>
                 <!-- Search button (always visible) -->
-                <button type="button" id="explore-search-button" class="flex items-center gap-1.5 px-3 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-r-lg border border-blue-600 transition-colors duration-150 flex-shrink-0">
+                <button type="button" id="explore-search-button" class="flex items-center gap-1.5 px-3 text-sm font-medium text-white rounded-r-lg transition-colors duration-150 flex-shrink-0" style="background-color: var(--color-primary); border: 1px solid var(--color-primary);">
                     <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 20 20">
                         <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
                     </svg>

--- a/folio_api/templates/jinja2/explore/tree.html
+++ b/folio_api/templates/jinja2/explore/tree.html
@@ -153,22 +153,26 @@
     <!-- Tree Panel -->
     <div id="tree-container" class="w-full md:w-2/5 lg:w-1/3 p-2 md:h-[calc(85vh-110px)] md:overflow-hidden flex flex-col">
         <div class="flex justify-between items-center mb-1">
-            <h2 class="text-lg font-semibold text-[--color-primary]">Search FOLIO</h2>
+            <h2 class="text-lg font-semibold text-[--color-primary]">Ontology Explorer</h2>
         </div>
         <div class="mb-1 sticky top-0 z-10 bg-white">
-            <div class="relative search-container flex">
-                <input type="search" id="explore-search-input" class="block w-full py-1.5 px-3 text-sm border border-gray-300 rounded-l-lg focus:ring-blue-500 focus:border-blue-500 border-r-0" placeholder="Search classes and properties...">
-                <!-- Search button (default state) -->
-                <button type="button" id="explore-search-button" class="items-center gap-1.5 px-3 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-r-lg border border-blue-600 transition-colors duration-150 flex-shrink-0" style="display:flex;">
-                    <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 20 20">
+            <div class="relative search-container">
+                <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
+                    <svg class="w-4 h-4 text-gray-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
                         <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
                     </svg>
-                    <span>Search</span>
-                </button>
-                <!-- Clear button (shown after search, replaces Search button) -->
-                <button type="button" id="explore-search-clear" class="items-center gap-1.5 px-3 text-sm font-medium text-white bg-gray-500 hover:bg-gray-600 rounded-r-lg border border-gray-500 transition-colors duration-150 flex-shrink-0" style="display:none;" aria-label="Clear filter">
+                </div>
+                <input type="search" id="explore-search-input" class="block w-full py-1 px-2 ps-10 text-sm border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500" style="padding-right: 6.5rem;" placeholder="Search classes and properties...">
+                <!-- Clear filter button (hidden until filter is active) -->
+                <button type="button" id="explore-search-clear" class="absolute inset-y-0 flex items-center gap-1 text-gray-400 hover:text-gray-600 text-xs" style="display:none; right: 2.2rem;" aria-label="Clear filter">
                     <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
                     <span>Clear</span>
+                </button>
+                <!-- Search submit button -->
+                <button type="button" id="explore-search-button" class="absolute inset-y-0 end-0 flex items-center pe-3 text-blue-600 hover:text-blue-800">
+                    <svg class="w-4 h-4" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
+                    </svg>
                 </button>
             </div>
             <!-- Match count (hidden until filter is active) -->

--- a/folio_api/templates/jinja2/explore/tree.html
+++ b/folio_api/templates/jinja2/explore/tree.html
@@ -181,7 +181,7 @@
                 <button id="expand-all-tree" class="text-xs bg-gray-200 hover:bg-gray-300 px-2 py-0.5 rounded">Expand All</button>
                 <button id="collapse-all-tree" class="text-xs bg-gray-200 hover:bg-gray-300 px-2 py-0.5 rounded">Collapse All</button>
             </div>
-            <div class="text-xs text-gray-500 italic">Tip: Double-click, press Space key, or click the arrow to expand/collapse</div>
+            <div class="text-xs text-gray-500 italic">To expand/collapse: Double-click or Space Key or Click Arrows</div>
         </div>
         <div id="explore-tree" class="overflow-y-auto flex-grow border border-gray-100 rounded p-2" style="max-height: calc(85vh - 110px);">
             <!-- Class section -->
@@ -217,8 +217,8 @@
                     <svg class="w-16 h-16 mx-auto text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
                     </svg>
-                    <h3 class="mt-2 text-xl font-medium">Select an item</h3>
-                    <p class="mt-1">Choose a class or property from the tree to view its details</p>
+                    <h3 class="mt-2 text-xl font-medium">Search or Browse Items</h3>
+                    <p class="mt-1">Expand or search the categories to view item details.</p>
                 </div>
             </div>
         </div>

--- a/folio_api/templates/jinja2/explore/tree.html
+++ b/folio_api/templates/jinja2/explore/tree.html
@@ -1,0 +1,249 @@
+{% extends "layouts/base.html" %}
+
+{% block title %}FOLIO Ontology Explorer{% endblock %}
+
+{% block meta_description %}Interactive explorer for FOLIO classes and properties in a unified tree view{% endblock %}
+{% block meta_keywords %}legal, ontology, standard, open, information, taxonomy, properties, tree, explorer{% endblock %}
+
+{% block header_title %}FOLIO Ontology Explorer{% endblock %}
+{% block header_subtitle %}Navigate FOLIO classes and properties{% endblock %}
+
+{% block header %}
+<header class="bg-[--color-primary] py-6 text-white">
+    <div class="container mx-auto px-4">
+        <div class="flex justify-between items-start">
+            <div>
+                <h1 class="text-3xl font-bold">FOLIO Ontology Explorer</h1>
+            </div>
+            <div class="hidden md:block header-buttons">
+                <a href="/taxonomy/browse" class="inline-block bg-white text-[--color-primary] font-semibold px-4 py-2 rounded hover:bg-opacity-90 transition-colors duration-200 mr-2">Browse Classes</a>
+                <a href="/properties/browse" class="inline-block bg-white text-[--color-primary] font-semibold px-4 py-2 rounded hover:bg-opacity-90 transition-colors duration-200 mr-2">Browse Properties</a>
+                <a href="https://openlegalstandard.org/" target="_blank" class="inline-block bg-transparent text-white border border-white font-semibold px-4 py-2 rounded hover:bg-white hover:bg-opacity-10 transition-colors duration-200 mr-2">FOLIO Website</a>
+                <a href="https://openlegalstandard.org/education/" target="_blank" class="inline-block bg-transparent text-white border border-white font-semibold px-4 py-2 rounded hover:bg-white hover:bg-opacity-10 transition-colors duration-200">Learn More</a>
+            </div>
+        </div>
+    </div>
+</header>
+{% endblock %}
+
+{% block extra_head %}
+<style>
+    /* Hide native browser clear button on search inputs (we use a custom one) */
+    #explore-search-input::-webkit-search-cancel-button { -webkit-appearance: none; display: none; }
+    #explore-search-input::-webkit-search-decoration { -webkit-appearance: none; }
+
+    .children-container {
+        border-left: 1px solid rgba(209, 213, 219, 0.7);
+        margin-left: 4px;
+        padding-left: 10px;
+    }
+    .tree-node { margin: 1px 0; }
+
+    /* Root-level styling within each section */
+    .section-tree-root > .tree-node > .node-content {
+        background-color: rgba(241, 245, 249, 0.7);
+        border-left: 3px solid var(--color-primary, rgb(24, 70, 120));
+        font-weight: 600;
+        padding-left: 6px;
+        margin-bottom: 2px;
+    }
+    .section-tree-root > .tree-node > .children-container > .tree-node > .node-content {
+        font-weight: 500;
+        border-bottom: 1px solid rgba(209, 213, 219, 0.5);
+    }
+    .section-tree-root > .tree-node > .children-container > .tree-node > .children-container > .tree-node > .node-content {
+        font-weight: normal;
+        font-size: 0.93rem;
+    }
+    .node-content {
+        padding: 3px 8px;
+        border-bottom: 1px solid rgba(229, 231, 235, 0.3);
+        line-height: 1.2;
+        font-size: 0.95rem;
+    }
+    .leaf-indicator {
+        width: 20px; height: 20px;
+        display: inline-flex; align-items: center; justify-content: center;
+        flex-shrink: 0; margin-right: 4px;
+    }
+
+    /* Search highlight */
+    .tree-node-highlighted > .node-content {
+        background-color: var(--color-primary, rgb(24, 70, 120)) !important;
+        color: white !important;
+        border-bottom-color: transparent !important;
+        border-left-color: transparent !important;
+    }
+    .tree-node-highlighted .node-label span.bg-blue-100 {
+        background-color: rgba(229, 231, 235, 0.7);
+        padding: 0 2px; border-radius: 2px; font-weight: bold;
+        color: var(--color-primary, rgb(24, 70, 120));
+    }
+    .children-container .tree-node:not(.selected):not(.tree-node-highlighted):not(.tree-node-match) > .node-content {
+        background-color: white;
+        color: var(--color-text-default, rgb(16, 16, 16));
+    }
+
+    /* Split-pane drag handle */
+    .split-handle {
+        width: 6px; cursor: col-resize; background: transparent;
+        flex-shrink: 0; position: relative; z-index: 10;
+        transition: background-color 0.15s;
+    }
+    .split-handle::after {
+        content: ''; position: absolute; top: 50%; left: 50%;
+        transform: translate(-50%, -50%); width: 2px; height: 32px;
+        border-radius: 1px; background-color: #d1d5db;
+        transition: background-color 0.15s, height 0.15s;
+    }
+    .split-handle:hover { background-color: rgba(59, 130, 246, 0.08); }
+    .split-handle:hover::after { background-color: #3b82f6; height: 48px; }
+    @media (max-width: 767px) { .split-handle { display: none; } }
+
+    /* Section headers — use identical box model as .node-content so chevrons & text align */
+    /* .node-content = padding: 2px 6px; .expand-icon = width: 20px, margin-right: 4px */
+    .section-header {
+        display: flex; align-items: center; justify-content: space-between;
+        padding: 2px 6px; border-radius: 4px; cursor: pointer;
+        user-select: none; margin-bottom: 4px; transition: background-color 0.15s;
+    }
+    .section-header:hover { filter: brightness(0.95); }
+    .section-header-class {
+        box-shadow: inset 4px 0 0 #3b82f6;  /* colored accent without affecting layout */
+        background-color: rgba(59, 130, 246, 0.08);
+    }
+    .section-header-property {
+        box-shadow: inset 4px 0 0 #14b8a6;
+        background-color: rgba(20, 184, 166, 0.08);
+    }
+    .section-header .section-title {
+        font-weight: 600; font-size: 0.85rem;
+    }
+    .section-header-class .section-title { color: #1d4ed8; }
+    .section-header-property .section-title { color: #0f766e; }
+    .section-chevron {
+        transition: transform 0.2s ease;
+        width: 20px; height: 20px; flex-shrink: 0;
+        margin-right: 4px;
+        display: inline-flex; align-items: center; justify-content: center;
+        transform: rotate(90deg); /* expanded = pointing down */
+    }
+    .section-chevron.collapsed { transform: rotate(0deg); /* collapsed = pointing right */ }
+    .section-count {
+        font-size: 0.7rem; padding: 1px 6px; border-radius: 9999px;
+        font-weight: 600; margin-left: 6px;
+    }
+    .section-header-class .section-count {
+        background-color: rgba(59, 130, 246, 0.15); color: #1d4ed8;
+    }
+    .section-header-property .section-count {
+        background-color: rgba(20, 184, 166, 0.15); color: #0f766e;
+    }
+</style>
+{% endblock %}
+
+{% block navbar %}
+<div class="bg-white border-b mb-0 pb-0">
+    <div class="container mx-auto px-2 py-1">
+        <div class="flex flex-wrap gap-2"></div>
+    </div>
+</div>
+{% endblock %}
+
+{% block content %}
+<div class="flex flex-col md:flex-row tree-explorer-container bg-white rounded-lg shadow-md overflow-hidden -mx-4 mt-0" style="min-height: calc(85vh - 110px);">
+    <!-- Tree Panel -->
+    <div id="tree-container" class="w-full md:w-2/5 lg:w-1/3 p-2 md:h-[calc(85vh-110px)] md:overflow-hidden flex flex-col">
+        <div class="flex justify-between items-center mb-1">
+            <h2 class="text-lg font-semibold text-[--color-primary]">Ontology Explorer</h2>
+        </div>
+        <div class="mb-1 sticky top-0 z-10 bg-white">
+            <div class="relative search-container">
+                <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
+                    <svg class="w-4 h-4 text-gray-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
+                    </svg>
+                </div>
+                <input type="search" id="explore-search-input" class="block w-full py-1 px-2 ps-10 text-sm border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500" style="padding-right: 6.5rem;" placeholder="Search classes and properties...">
+                <!-- Clear filter button (hidden until filter is active) -->
+                <button type="button" id="explore-search-clear" class="absolute inset-y-0 flex items-center gap-1 text-gray-400 hover:text-gray-600 text-xs" style="display:none; right: 2.2rem;" aria-label="Clear filter">
+                    <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                    <span>Clear</span>
+                </button>
+                <!-- Search submit button -->
+                <button type="button" id="explore-search-button" class="absolute inset-y-0 end-0 flex items-center pe-3 text-blue-600 hover:text-blue-800">
+                    <svg class="w-4 h-4" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
+                    </svg>
+                </button>
+            </div>
+            <!-- Match count (hidden until filter is active) -->
+            <div id="search-match-count" class="text-xs text-gray-500 mt-0.5 px-1" style="display:none;"></div>
+        </div>
+        <div class="tree-controls mb-1 flex flex-col space-y-0.5">
+            <div class="flex space-x-2">
+                <button id="expand-all-tree" class="text-xs bg-gray-200 hover:bg-gray-300 px-2 py-0.5 rounded">Expand All</button>
+                <button id="collapse-all-tree" class="text-xs bg-gray-200 hover:bg-gray-300 px-2 py-0.5 rounded">Collapse All</button>
+            </div>
+            <div class="text-xs text-gray-500 italic">Tip: Double-click, press Space key, or click the arrow to expand/collapse</div>
+        </div>
+        <div id="explore-tree" class="overflow-y-auto flex-grow border border-gray-100 rounded p-2" style="max-height: calc(85vh - 110px);">
+            <!-- Class section -->
+            <div id="class-section">
+                <div class="section-header section-header-class" data-section="class">
+                    <div class="flex items-center">
+                        <svg class="section-chevron" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 3 11 8 6 13"></polyline></svg>
+                        <span class="section-title"><strong>NOUNS</strong> (Classes)</span>
+                        <span class="section-count" id="class-count"></span>
+                    </div>
+                </div>
+                <ul id="class-tree-root" class="section-tree-root"></ul>
+            </div>
+            <!-- Property section -->
+            <div id="property-section" style="margin-top: 8px;">
+                <div class="section-header section-header-property" data-section="property">
+                    <div class="flex items-center">
+                        <svg class="section-chevron" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 3 11 8 6 13"></polyline></svg>
+                        <span class="section-title"><strong>VERBS</strong> (Properties)</span>
+                        <span class="section-count" id="property-count"></span>
+                    </div>
+                </div>
+                <ul id="property-tree-root" class="section-tree-root"></ul>
+            </div>
+        </div>
+    </div>
+
+    <!-- Detail Panel -->
+    <div id="detail-container" class="w-full md:w-3/5 lg:w-2/3 p-3 bg-gray-50 max-w-full md:h-[calc(85vh-110px)] flex flex-col overflow-y-auto">
+        <div id="class-details">
+            <div class="flex items-center justify-center h-full text-gray-500">
+                <div class="text-center">
+                    <svg class="w-16 h-16 mx-auto text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+                    </svg>
+                    <h3 class="mt-2 text-xl font-medium">Select an item</h3>
+                    <p class="mt-1">Choose a class or property from the tree to view its details</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    {{ typeahead_js_source|safe }}
+</script>
+<script src="/static/js/split_pane.js"></script>
+<script src="/static/js/unified_tree.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        if (typeof initSplitPane === 'function') {
+            initSplitPane({ storageKey: 'folio-explore-split', defaultPct: 33 });
+        }
+        if (typeof initializeUnifiedTree === 'function') {
+            initializeUnifiedTree();
+        }
+    });
+</script>
+{% endblock %}

--- a/folio_api/templates/jinja2/explore/tree.html
+++ b/folio_api/templates/jinja2/explore/tree.html
@@ -102,8 +102,8 @@
     /* .node-content = padding: 2px 6px; .expand-icon = width: 20px, margin-right: 4px */
     .section-header {
         display: flex; align-items: center; justify-content: space-between;
-        padding: 2px 6px; border-radius: 4px; cursor: pointer;
-        user-select: none; margin-bottom: 4px; transition: background-color 0.15s;
+        padding: 8px 6px; border-radius: 4px; cursor: pointer;
+        user-select: none; margin-bottom: 6px; transition: background-color 0.15s;
     }
     .section-header:hover { filter: brightness(0.95); }
     .section-header-class {
@@ -115,7 +115,7 @@
         background-color: rgba(20, 184, 166, 0.08);
     }
     .section-header .section-title {
-        font-weight: 600; font-size: 0.85rem;
+        font-weight: 600; font-size: 0.9rem;
     }
     .section-header-class .section-title { color: #1d4ed8; }
     .section-header-property .section-title { color: #0f766e; }

--- a/folio_api/templates/jinja2/explore/tree.html
+++ b/folio_api/templates/jinja2/explore/tree.html
@@ -153,26 +153,22 @@
     <!-- Tree Panel -->
     <div id="tree-container" class="w-full md:w-2/5 lg:w-1/3 p-2 md:h-[calc(85vh-110px)] md:overflow-hidden flex flex-col">
         <div class="flex justify-between items-center mb-1">
-            <h2 class="text-lg font-semibold text-[--color-primary]">Ontology Explorer</h2>
+            <h2 class="text-lg font-semibold text-[--color-primary]">Search FOLIO</h2>
         </div>
         <div class="mb-1 sticky top-0 z-10 bg-white">
-            <div class="relative search-container">
-                <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
-                    <svg class="w-4 h-4 text-gray-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+            <div class="relative search-container flex">
+                <input type="search" id="explore-search-input" class="block w-full py-1.5 px-3 text-sm border border-gray-300 rounded-l-lg focus:ring-blue-500 focus:border-blue-500 border-r-0" placeholder="Search classes and properties...">
+                <!-- Search button (default state) -->
+                <button type="button" id="explore-search-button" class="items-center gap-1.5 px-3 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-r-lg border border-blue-600 transition-colors duration-150 flex-shrink-0" style="display:flex;">
+                    <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 20 20">
                         <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
                     </svg>
-                </div>
-                <input type="search" id="explore-search-input" class="block w-full py-1 px-2 ps-10 text-sm border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500" style="padding-right: 6.5rem;" placeholder="Search classes and properties...">
-                <!-- Clear filter button (hidden until filter is active) -->
-                <button type="button" id="explore-search-clear" class="absolute inset-y-0 flex items-center gap-1 text-gray-400 hover:text-gray-600 text-xs" style="display:none; right: 2.2rem;" aria-label="Clear filter">
+                    <span>Search</span>
+                </button>
+                <!-- Clear button (shown after search, replaces Search button) -->
+                <button type="button" id="explore-search-clear" class="items-center gap-1.5 px-3 text-sm font-medium text-white bg-gray-500 hover:bg-gray-600 rounded-r-lg border border-gray-500 transition-colors duration-150 flex-shrink-0" style="display:none;" aria-label="Clear filter">
                     <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
                     <span>Clear</span>
-                </button>
-                <!-- Search submit button -->
-                <button type="button" id="explore-search-button" class="absolute inset-y-0 end-0 flex items-center pe-3 text-blue-600 hover:text-blue-800">
-                    <svg class="w-4 h-4" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
-                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
-                    </svg>
                 </button>
             </div>
             <!-- Match count (hidden until filter is active) -->

--- a/folio_api/templates/jinja2/explore/tree.html
+++ b/folio_api/templates/jinja2/explore/tree.html
@@ -16,8 +16,6 @@
                 <h1 class="text-3xl font-bold">FOLIO Ontology Explorer</h1>
             </div>
             <div class="hidden md:block header-buttons">
-                <a href="/taxonomy/browse" class="inline-block bg-white text-[--color-primary] font-semibold px-4 py-2 rounded hover:bg-opacity-90 transition-colors duration-200 mr-2">Browse Classes</a>
-                <a href="/properties/browse" class="inline-block bg-white text-[--color-primary] font-semibold px-4 py-2 rounded hover:bg-opacity-90 transition-colors duration-200 mr-2">Browse Properties</a>
                 <a href="https://openlegalstandard.org/" target="_blank" class="inline-block bg-transparent text-white border border-white font-semibold px-4 py-2 rounded hover:bg-white hover:bg-opacity-10 transition-colors duration-200 mr-2">FOLIO Website</a>
                 <a href="https://openlegalstandard.org/education/" target="_blank" class="inline-block bg-transparent text-white border border-white font-semibold px-4 py-2 rounded hover:bg-white hover:bg-opacity-10 transition-colors duration-200">Learn More</a>
             </div>

--- a/folio_api/templates/jinja2/explore/tree.html
+++ b/folio_api/templates/jinja2/explore/tree.html
@@ -153,26 +153,24 @@
     <!-- Tree Panel -->
     <div id="tree-container" class="w-full md:w-2/5 lg:w-1/3 p-2 md:h-[calc(85vh-110px)] md:overflow-hidden flex flex-col">
         <div class="flex justify-between items-center mb-1">
-            <h2 class="text-lg font-semibold text-[--color-primary]">Ontology Explorer</h2>
+            <h2 class="text-lg font-semibold text-[--color-primary]">Explore FOLIO</h2>
         </div>
         <div class="mb-1 sticky top-0 z-10 bg-white">
-            <div class="relative search-container">
-                <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
-                    <svg class="w-4 h-4 text-gray-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
-                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
-                    </svg>
+            <div class="search-container flex">
+                <div class="relative flex-grow">
+                    <input type="search" id="explore-search-input" class="block w-full py-1.5 px-3 pr-16 text-sm border border-gray-300 rounded-l-lg focus:ring-blue-500 focus:border-blue-500 border-r-0" placeholder="Search FOLIO's nouns and verbs...">
+                    <!-- Clear button (inside input, hidden until filter is active) -->
+                    <button type="button" id="explore-search-clear" class="absolute inset-y-0 right-1 flex items-center gap-1 px-2 my-1 text-gray-700 hover:text-gray-900 text-xs font-semibold rounded bg-gray-100 hover:bg-gray-200 transition-colors duration-150" style="display:none;" aria-label="Clear filter">
+                        <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+                        <span>Clear</span>
+                    </button>
                 </div>
-                <input type="search" id="explore-search-input" class="block w-full py-1 px-2 ps-10 text-sm border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500" style="padding-right: 6.5rem;" placeholder="Search classes and properties...">
-                <!-- Clear filter button (hidden until filter is active) -->
-                <button type="button" id="explore-search-clear" class="absolute inset-y-0 flex items-center gap-1 text-gray-400 hover:text-gray-600 text-xs" style="display:none; right: 2.2rem;" aria-label="Clear filter">
-                    <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
-                    <span>Clear</span>
-                </button>
-                <!-- Search submit button -->
-                <button type="button" id="explore-search-button" class="absolute inset-y-0 end-0 flex items-center pe-3 text-blue-600 hover:text-blue-800">
-                    <svg class="w-4 h-4" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+                <!-- Search button (always visible) -->
+                <button type="button" id="explore-search-button" class="flex items-center gap-1.5 px-3 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-r-lg border border-blue-600 transition-colors duration-150 flex-shrink-0">
+                    <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 20 20">
                         <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
                     </svg>
+                    <span>Search</span>
                 </button>
             </div>
             <!-- Match count (hidden until filter is active) -->

--- a/folio_api/templates/jinja2/properties/browse.html
+++ b/folio_api/templates/jinja2/properties/browse.html
@@ -1,0 +1,75 @@
+{% extends "layouts/base.html" %}
+
+{% block title %}FOLIO Object Properties{% endblock %}
+
+{% block meta_description %}Browse the root-level OWL object properties in the FOLIO ontology{% endblock %}
+{% block meta_keywords %}legal, ontology, standard, open, information, properties, object properties{% endblock %}
+
+{% block header_title %}FOLIO Object Properties{% endblock %}
+{% block header_subtitle %}Browse the root-level OWL object properties in the FOLIO ontology{% endblock %}
+
+{% block navigation_buttons %}
+<div class="flex space-x-2">
+    <a href="/properties/tree" class="btn btn-secondary">Switch to Tree View</a>
+    <a href="/taxonomy/browse" class="btn btn-secondary">Browse Classes</a>
+</div>
+{% endblock %}
+
+{% block content %}
+<p class="mb-6 text-gray-600">These are the root-level object properties in the FOLIO ontology, representing fundamental relationships between legal concepts.</p>
+
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 auto-rows-fr">
+    {% for item in root_data %}
+    <div class="bg-white rounded-lg shadow p-8 flex flex-col h-full min-h-56">
+        <h2 class="text-xl font-semibold mb-2 text-[--color-primary]">
+            {# INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged #}
+            <a href="/properties/tree?node={{ item.prop.iri }}">{{ (item.prop.label or "Unnamed Property")|strip_folio_prefix }}</a>
+        </h2>
+        <p class="text-gray-500 text-sm mb-2 truncate" title="{{ item.prop.iri }}">IRI: {{ item.prop.iri }}</p>
+        <div class="flex-grow mb-4">
+            <p class="text-gray-700 line-clamp-3" title="{{ item.prop.definition or 'No definition available' }}">{{ item.prop.definition or "No definition available" }}</p>
+        </div>
+        {% if item.domain_summary %}
+        <p class="text-xs text-teal-600 mb-1 truncate" title="Domain: {{ item.domain_summary }}">Domain: {{ item.domain_summary }}</p>
+        {% endif %}
+        {% if item.range_summary %}
+        <p class="text-xs text-orange-600 mb-2 truncate" title="Range: {{ item.range_summary }}">Range: {{ item.range_summary }}</p>
+        {% endif %}
+        <div class="flex justify-between items-center mt-auto">
+            <span class="text-xs text-gray-500">{{ item.child_count }} sub-properties</span>
+            <a href="/properties/tree?node={{ item.prop.iri }}" class="text-blue-500 text-sm font-medium">View details &rarr;</a>
+        </div>
+    </div>
+    {% endfor %}
+</div>
+{% endblock %}
+
+{% block extra_content %}
+<div class="bg-white border-b">
+    <div class="container mx-auto px-4 py-6">
+        <div class="flex flex-col md:flex-row gap-6">
+            <div class="flex-1">
+                <h2 class="text-xl font-bold text-[--color-primary] mb-2">About FOLIO Object Properties</h2>
+                <p class="text-gray-700 mb-2">Object properties in FOLIO define relationships (verbs/predicates) between legal concepts, such as "drafted", "filed", "signed", and "governed by".</p>
+                <p class="text-gray-700">Explore the <a href="https://openlegalstandard.org/resources/folio-python-library/" class="text-blue-600 hover:underline">FOLIO Python Library</a> to integrate FOLIO ontology into your applications.</p>
+            </div>
+            <div class="flex-1">
+                <h2 class="text-xl font-bold text-[--color-primary] mb-2">Resources</h2>
+                <ul class="list-disc list-inside text-gray-700 space-y-1">
+                    <li><a href="https://openlegalstandard.org/" class="text-blue-600 hover:underline">Official FOLIO Website</a></li>
+                    <li><a href="https://openlegalstandard.org/education/" class="text-blue-600 hover:underline">FOLIO Education Resources</a></li>
+                    <li><a href="/taxonomy/browse" class="text-blue-600 hover:underline">Browse FOLIO Classes</a></li>
+                    <li><a href="https://github.com/alea-institute/folio-api" class="text-blue-600 hover:underline">FOLIO API on GitHub</a></li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    // Typeahead search initialization
+    {{ typeahead_js_source|safe }}
+</script>
+{% endblock %}

--- a/folio_api/templates/jinja2/properties/property_detail.html
+++ b/folio_api/templates/jinja2/properties/property_detail.html
@@ -55,8 +55,8 @@
         <div class="flex justify-between items-start">
             <div>
                 <div class="flex items-center mb-2">
-                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800 mr-2">Object Property</span>
-                    <h3 class="text-xl font-semibold text-[--color-primary]">Identification</h3>
+                    <h3 class="text-2xl font-semibold text-[--color-primary]">{{ (prop.label or "Unnamed Property")|strip_folio_prefix }}</h3>
+                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800 ml-3">Verb (Property)</span>
                 </div>
                 <div class="flex flex-col sm:flex-row sm:items-center text-gray-500 text-sm mb-4">
                     <span class="font-medium mb-1 sm:mb-0 sm:mr-1.5 flex-shrink-0">IRI:</span>
@@ -74,22 +74,14 @@
         <div class="bg-gray-50 rounded-lg p-4 mt-4">
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div class="flex flex-col">
-                    <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-1">Label</span>
-                    <span class="text-gray-800 font-medium">{{ (prop.label or "N/A")|strip_folio_prefix }}</span>
-                </div>
-                <div class="flex flex-col">
                     <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-1">Preferred Label</span>
-                    <span class="text-gray-800">{{ (prop.preferred_label or "N/A")|strip_folio_prefix }}</span>
-                </div>
-                <div class="flex flex-col">
-                    <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-1">Inverse Of</span>
-                    {% if inverse_data %}
-                    <a href="/properties/tree?node={{ inverse_data.iri }}" class="text-blue-600 hover:underline">{{ inverse_data.label }}</a>
+                    {% if prop.preferred_label %}
+                    <span class="text-gray-800">{{ prop.preferred_label|strip_folio_prefix }}</span>
                     {% else %}
-                    <span class="text-gray-800">N/A</span>
+                    <span class="text-gray-400 italic">N/A</span>
                     {% endif %}
                 </div>
-                <div class="md:col-span-3">
+                <div class="flex flex-col">
                     <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-1">Alternative Labels</span>
                     {% if prop.alternative_labels %}
                     <div class="flex flex-wrap gap-1 mt-1">
@@ -99,13 +91,21 @@
                         {% endfor %}
                     </div>
                     {% else %}
-                    <p class="text-gray-700">None</p>
+                    <p class="text-gray-400 italic">None</p>
+                    {% endif %}
+                </div>
+                <div class="flex flex-col">
+                    <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-1">Inverse Of</span>
+                    {% if inverse_data %}
+                    <a href="/properties/tree?node={{ inverse_data.iri }}" class="text-blue-600 hover:underline">{{ inverse_data.label }}</a>
+                    {% else %}
+                    <span class="text-gray-400 italic">N/A</span>
                     {% endif %}
                 </div>
             </div>
         </div>
     </section>
-    
+
     <!-- Definition and Examples -->
     <section class="card animate-fade-in border-t-4 border-emerald-500">
         <div class="flex items-start mb-4">
@@ -164,7 +164,7 @@
                     {% else %}
                     <li class="flex items-center">
                         <span class="text-gray-400 mr-2">&bull;</span>
-                        <span class="text-gray-500 italic">None (root property)</span>
+                        <span class="text-gray-400 italic">None (root property)</span>
                     </li>
                     {% endif %}
                 </ul>
@@ -191,7 +191,7 @@
                         {% else %}
                         <li class="flex items-center">
                             <span class="text-gray-400 mr-2">&bull;</span>
-                            <span class="text-gray-500 italic">None</span>
+                            <span class="text-gray-400 italic">None</span>
                         </li>
                         {% endif %}
                     </ul>

--- a/folio_api/templates/jinja2/properties/property_detail.html
+++ b/folio_api/templates/jinja2/properties/property_detail.html
@@ -84,10 +84,10 @@
                 <div class="flex flex-col">
                     <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-1">Alternative Labels</span>
                     {% if prop.alternative_labels %}
-                    <div class="flex flex-wrap gap-1 mt-1">
+                    <div class="flex flex-wrap gap-1.5 mt-1">
                         {% for label in prop.alternative_labels %}
                         {# INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged #}
-                        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-50 text-blue-700">{{ label|strip_folio_prefix }}</span>
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium bg-blue-50 text-blue-700">{{ label|strip_folio_prefix }}</span>
                         {% endfor %}
                     </div>
                     {% else %}

--- a/folio_api/templates/jinja2/properties/property_detail.html
+++ b/folio_api/templates/jinja2/properties/property_detail.html
@@ -1,0 +1,361 @@
+{% extends "layouts/base.html" %}
+
+{# INTERIM: strip_folio_prefix usages below can be removed once FOLIO PR #5 is merged #}
+{% block title %}{{ (prop.label or "Unnamed Property")|strip_folio_prefix }} - FOLIO Ontology{% endblock %}
+
+{% block meta_description %}{{ prop.definition or "No definition available" }}{% endblock %}
+{% block meta_keywords %}legal, ontology, standard, open, information, property, {{ (prop.label or "")|strip_folio_prefix }}{% endblock %}
+
+{% block header_title %}{{ (prop.label or "Unnamed Property")|strip_folio_prefix }}{% endblock %}
+{% block header_subtitle %}{{ prop.definition or "No definition available" }}{% endblock %}
+
+{% block extra_head %}
+<script src="/static/js/vendor/cytoscape.min.js"></script>
+<script src="/static/js/vendor/dagre.min.js"></script>
+<script src="/static/js/vendor/cytoscape-dagre.min.js"></script>
+<script src="/static/js/vendor/popper.min.js"></script>
+<script src="/static/js/vendor/cytoscape-popper.min.js"></script>
+<script src="/static/js/vendor/tippy.umd.min.js"></script>
+{% endblock %}
+
+{% block navigation_buttons %}
+<div class="bg-gray-50 border border-gray-100 rounded-lg p-3 mb-4 shadow-sm">
+    <div class="flex flex-col md:flex-row md:items-center space-y-4 md:space-y-0">
+        <div class="flex flex-col md:flex-row md:items-center space-y-2 md:space-y-0">
+            <h3 class="text-[--color-primary] font-medium text-sm mb-2 md:mb-0 md:mr-3">Navigation:</h3>
+            <div class="flex space-x-2">
+                <a href="/properties/browse" class="btn btn-secondary flex items-center text-sm hover:bg-[--color-primary] hover:text-white transition-colors">
+                    <svg class="w-3.5 h-3.5 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
+                    </svg>
+                    Browse Properties
+                </a>
+                <a href="/properties/tree" class="btn btn-secondary flex items-center text-sm hover:bg-[--color-primary] hover:text-white transition-colors">
+                    <svg class="w-3.5 h-3.5 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 5a1 1 0 011-1h14a1 1 0 011 1v2a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM4 13a1 1 0 011-1h6a1 1 0 011 1v6a1 1 0 01-1 1H5a1 1 0 01-1-1v-6zM16 13a1 1 0 011-1h2a1 1 0 011 1v6a1 1 0 01-1 1h-2a1 1 0 01-1-1v-6z" />
+                    </svg>
+                    Property Tree
+                </a>
+                <a href="/taxonomy/browse" class="btn btn-secondary flex items-center text-sm hover:bg-[--color-primary] hover:text-white transition-colors">
+                    <svg class="w-3.5 h-3.5 mr-1.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+                    </svg>
+                    Browse Classes
+                </a>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block content %}
+<div class="max-w-4xl mx-auto space-y-6">
+    <!-- Identification -->
+    <section class="card animate-fade-in border-t-4 border-[--color-primary]">
+        <div class="flex justify-between items-start">
+            <div>
+                <div class="flex items-center mb-2">
+                    <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800 mr-2">Object Property</span>
+                    <h3 class="text-xl font-semibold text-[--color-primary]">Identification</h3>
+                </div>
+                <div class="flex flex-col sm:flex-row sm:items-center text-gray-500 text-sm mb-4">
+                    <span class="font-medium mb-1 sm:mb-0 sm:mr-1.5 flex-shrink-0">IRI:</span>
+                    <div class="overflow-hidden flex-1 min-w-0 mb-1 sm:mb-0 sm:mr-2">
+                        <span class="font-mono break-all block w-full" id="iri-value" title="{{ prop.iri }}">{{ prop.iri }}</span>
+                    </div>
+                    <button onclick="copyIRI()" class="self-end sm:self-auto sm:ml-auto py-1 px-2 rounded text-blue-600 hover:bg-blue-50 transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-blue-500 flex-shrink-0" aria-label="Copy IRI to clipboard">
+                        <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5H6a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2v-1M8 5a2 2 0 002 2h2a2 2 0 002-2M8 5a2 2 0 012-2h2a2 2 0 012 2m0 0h2a2 2 0 012 2v3m2 4H10m0 0l3-3m-3 3l3 3" />
+                        </svg>
+                    </button>
+                </div>
+            </div>
+        </div>
+        <div class="bg-gray-50 rounded-lg p-4 mt-4">
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div class="flex flex-col">
+                    <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-1">Label</span>
+                    <span class="text-gray-800 font-medium">{{ (prop.label or "N/A")|strip_folio_prefix }}</span>
+                </div>
+                <div class="flex flex-col">
+                    <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-1">Preferred Label</span>
+                    <span class="text-gray-800">{{ (prop.preferred_label or "N/A")|strip_folio_prefix }}</span>
+                </div>
+                <div class="flex flex-col">
+                    <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-1">Inverse Of</span>
+                    {% if inverse_data %}
+                    <a href="/properties/tree?node={{ inverse_data.iri }}" class="text-blue-600 hover:underline">{{ inverse_data.label }}</a>
+                    {% else %}
+                    <span class="text-gray-800">N/A</span>
+                    {% endif %}
+                </div>
+                <div class="md:col-span-3">
+                    <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-1">Alternative Labels</span>
+                    {% if prop.alternative_labels %}
+                    <div class="flex flex-wrap gap-1 mt-1">
+                        {% for label in prop.alternative_labels %}
+                        {# INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged #}
+                        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-50 text-blue-700">{{ label|strip_folio_prefix }}</span>
+                        {% endfor %}
+                    </div>
+                    {% else %}
+                    <p class="text-gray-700">None</p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </section>
+    
+    <!-- Definition and Examples -->
+    <section class="card animate-fade-in border-t-4 border-emerald-500">
+        <div class="flex items-start mb-4">
+            <svg class="w-5 h-5 mt-1 mr-2 text-emerald-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 8h10M7 12h10M7 16h10" />
+            </svg>
+            <h3 class="text-xl font-semibold text-[--color-primary]">Definition</h3>
+        </div>
+        <div class="bg-gradient-to-r from-emerald-50 to-transparent p-4 rounded-lg mb-6">
+            <p class="text-gray-700">{{ prop.definition or "No definition available." }}</p>
+        </div>
+        {% if prop.examples %}
+        <div class="flex items-start mb-3">
+            <svg class="w-4 h-4 mt-1 mr-2 text-emerald-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
+            </svg>
+            <h4 class="text-lg font-medium text-[--color-primary]">Examples</h4>
+        </div>
+        <div class="bg-gray-50 rounded-lg p-4">
+            <ul class="list-none space-y-2">
+                {% for example in prop.examples %}
+                <li class="flex">
+                    <span class="text-emerald-500 mr-2">&bull;</span>
+                    <span>{{ example }}</span>
+                </li>
+                {% endfor %}
+            </ul>
+        </div>
+        {% endif %}
+    </section>
+    
+    <!-- Property Relationships -->
+    <section class="card animate-fade-in border-t-4 border-blue-500">
+        <div class="flex items-start mb-4">
+            <svg class="w-5 h-5 mt-1 mr-2 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+            </svg>
+            <h3 class="text-xl font-semibold text-[--color-primary]">Property Relationships</h3>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div class="bg-blue-50 rounded-lg p-4">
+                <div class="flex items-center mb-3">
+                    <svg class="w-4 h-4 mr-2 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
+                    </svg>
+                    <p class="text-gray-700 text-sm font-medium uppercase tracking-wide">Parent Properties</p>
+                </div>
+                <ul class="list-none space-y-2">
+                    {% if parents %}
+                        {% for parent in parents %}
+                        <li class="flex items-center">
+                            <span class="text-blue-500 mr-2">&bull;</span>
+                            <a class="text-blue-700 hover:text-blue-900 hover:underline" href="/properties/tree?node={{ parent.iri }}">{{ parent.label }}</a>
+                        </li>
+                        {% endfor %}
+                    {% else %}
+                    <li class="flex items-center">
+                        <span class="text-gray-400 mr-2">&bull;</span>
+                        <span class="text-gray-500 italic">None (root property)</span>
+                    </li>
+                    {% endif %}
+                </ul>
+            </div>
+            <div class="bg-green-50 rounded-lg p-4">
+                <div class="flex items-center mb-3">
+                    <svg class="w-4 h-4 mr-2 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3" />
+                    </svg>
+                    <p class="text-gray-700 text-sm font-medium uppercase tracking-wide">
+                        Child Properties
+                        <span class="inline-flex items-center justify-center ml-2 bg-green-100 text-green-800 px-2 py-0.5 rounded-full text-xs">{{ children|length }}</span>
+                    </p>
+                </div>
+                <div class="max-h-60 overflow-y-auto">
+                    <ul class="list-none space-y-2">
+                        {% if children %}
+                            {% for child in children %}
+                            <li class="flex items-center">
+                                <span class="text-green-500 mr-2">&bull;</span>
+                                <a class="text-green-700 hover:text-green-900 hover:underline" href="/properties/tree?node={{ child.iri }}">{{ child.label }}</a>
+                            </li>
+                            {% endfor %}
+                        {% else %}
+                        <li class="flex items-center">
+                            <span class="text-gray-400 mr-2">&bull;</span>
+                            <span class="text-gray-500 italic">None</span>
+                        </li>
+                        {% endif %}
+                    </ul>
+                </div>
+            </div>
+        </div>
+        {% if inverse_data %}
+        <div class="mt-4 bg-purple-50 rounded-lg p-4">
+            <div class="flex items-center mb-2">
+                <svg class="w-4 h-4 mr-2 text-purple-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+                </svg>
+                <p class="text-gray-700 text-sm font-medium uppercase tracking-wide">Inverse Property</p>
+            </div>
+            <a class="text-purple-700 hover:text-purple-900 hover:underline font-medium" href="/properties/tree?node={{ inverse_data.iri }}">{{ inverse_data.label }}</a>
+        </div>
+        {% endif %}
+    </section>
+    
+    <!-- Domain & Range -->
+    <section class="card animate-fade-in border-t-4 border-teal-500">
+        <div class="flex items-start mb-4">
+            <svg class="w-5 h-5 mt-1 mr-2 text-teal-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 9l3 3-3 3m5 0h3M5 20h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+            </svg>
+            <h3 class="text-xl font-semibold text-[--color-primary]">Domain & Range</h3>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div class="bg-teal-50 rounded-lg p-4">
+                <div class="flex items-center mb-3">
+                    <p class="text-gray-700 text-sm font-medium uppercase tracking-wide">Domain (Subject Classes)</p>
+                </div>
+                <ul class="list-none space-y-2">
+                    {% if domain_classes %}
+                        {% for cls in domain_classes %}
+                        <li class="flex items-center">
+                            <span class="text-teal-500 mr-2">&bull;</span>
+                            <a class="text-teal-700 hover:text-teal-900 hover:underline" href="{{ cls.iri }}/html">{{ cls.label }}</a>
+                        </li>
+                        {% endfor %}
+                    {% else %}
+                    <li class="text-gray-500 italic">No domain specified</li>
+                    {% endif %}
+                </ul>
+            </div>
+            <div class="bg-orange-50 rounded-lg p-4">
+                <div class="flex items-center mb-3">
+                    <p class="text-gray-700 text-sm font-medium uppercase tracking-wide">Range (Object Classes)</p>
+                </div>
+                <ul class="list-none space-y-2">
+                    {% if range_classes %}
+                        {% for cls in range_classes %}
+                        <li class="flex items-center">
+                            <span class="text-orange-500 mr-2">&bull;</span>
+                            <a class="text-orange-700 hover:text-orange-900 hover:underline" href="{{ cls.iri }}/html">{{ cls.label }}</a>
+                        </li>
+                        {% endfor %}
+                    {% else %}
+                    <li class="text-gray-500 italic">No range specified</li>
+                    {% endif %}
+                </ul>
+            </div>
+        </div>
+    </section>
+    
+    <!-- Graph Visualization -->
+    <section class="card animate-fade-in border-t-4 border-purple-500">
+        <div class="flex items-start mb-4">
+            <svg class="w-5 h-5 mt-1 mr-2 text-purple-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 10l-2 1m0 0l-2-1m2 1v2.5M20 7l-2 1m2-1l-2-1m2 1v2.5M14 4l-2-1-2 1M4 7l2-1M4 7l2 1M4 7v2.5M12 21l-2-1m2 1l2-1m-2 1v-2.5M6 18l-2-1v-2.5M18 18l2-1v-2.5" />
+            </svg>
+            <h3 class="text-xl font-semibold text-[--color-primary]">Property Relationship Visualization</h3>
+        </div>
+        <p class="text-gray-600 mb-4 text-sm italic">Interactive graph showing property relationships - click on any node to navigate</p>
+        <div id="hierarchy-container" class="h-96 w-full border border-purple-200 rounded-lg relative shadow-inner bg-gradient-to-br from-purple-50 to-white">
+            <noscript>
+                <div class="absolute inset-0 flex items-center justify-center bg-gray-50 p-4 text-center">
+                    <div>
+                        <h4 class="mt-2 text-lg font-medium">Interactive visualization requires JavaScript</h4>
+                    </div>
+                </div>
+            </noscript>
+        </div>
+    </section>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    {{ typeahead_js_source|safe }}
+    
+    var nodes = {{ nodes|tojson|safe }};
+    var edges = {{ edges|tojson|safe }};
+    
+    function copyIRI() {
+        const iriElement = document.getElementById('iri-value');
+        if (iriElement) {
+            const iri = iriElement.getAttribute('title') || iriElement.textContent.trim();
+            navigator.clipboard.writeText(iri).then(() => { alert('IRI copied to clipboard'); }).catch(err => { console.error('Failed to copy', err); });
+        }
+    }
+    
+    document.addEventListener('DOMContentLoaded', function() {
+        if (typeof cytoscape === 'undefined') {
+            const container = document.getElementById('hierarchy-container');
+            if (container) container.innerHTML = '<div class="p-4 text-center"><p class="text-lg font-medium text-gray-700">Interactive visualization unavailable.</p></div>';
+            return;
+        }
+        
+        const cy = cytoscape({
+            container: document.getElementById('hierarchy-container'),
+            elements: [
+                ...nodes.map(node => ({ data: { id: node.id, label: node.label, description: node.description, relationship: node.relationship } })),
+                ...edges.map(edge => ({ data: { source: edge.source, target: edge.target, type: edge.type } }))
+            ],
+            style: [
+                { selector: 'node', style: { 'label': function(ele) { return ele.data('label') || ele.id() || 'Unnamed'; }, 'text-valign': 'center', 'text-halign': 'center', 'background-color': '#fff', 'border-width': 2, 'border-color': '#184678', 'width': '120px', 'height': '50px', 'text-wrap': 'wrap', 'text-max-width': '100px', 'font-size': '10px', 'color': '#184678', 'padding': '5px', 'shape': 'roundrectangle', 'cursor': 'pointer' } },
+                { selector: 'node[relationship="self"]', style: { 'background-color': '#184678', 'color': '#fff', 'border-color': '#184678', 'border-width': 3 } },
+                { selector: 'node[relationship="domain"]', style: { 'border-color': '#0d9488', 'background-color': '#f0fdfa' } },
+                { selector: 'node[relationship="range"]', style: { 'border-color': '#ea580c', 'background-color': '#fff7ed' } },
+                { selector: 'node[relationship="inverse"]', style: { 'border-color': '#9333ea', 'background-color': '#faf5ff' } },
+                { selector: 'edge', style: { 'width': 2, 'line-color': '#ccc', 'target-arrow-color': '#ccc', 'target-arrow-shape': 'triangle', 'curve-style': 'bezier' } },
+                { selector: 'edge[type="sub_property_of"]', style: { 'line-color': '#184678', 'target-arrow-color': '#184678' } },
+                { selector: 'edge[type="child_property"]', style: { 'line-color': '#29A35A', 'target-arrow-color': '#29A35A' } },
+                { selector: 'edge[type="domain"]', style: { 'line-color': '#0d9488', 'target-arrow-color': '#0d9488', 'line-style': 'dashed' } },
+                { selector: 'edge[type="range"]', style: { 'line-color': '#ea580c', 'target-arrow-color': '#ea580c', 'line-style': 'dashed' } },
+                { selector: 'edge[type="inverse_of"]', style: { 'line-color': '#9333ea', 'target-arrow-color': '#9333ea', 'line-style': 'dotted' } }
+            ],
+            layout: { name: 'grid' }
+        });
+        
+        try {
+            cy.layout({ name: 'dagre', rankDir: 'TB', rankSep: 75, nodeSep: 50, padding: 30, animate: true, animationDuration: 500 }).run();
+        } catch (error) {
+            cy.layout({ name: 'grid' }).run();
+        }
+        
+        cy.on('tap', 'node', function(evt) {
+            const node = evt.target;
+            const nodeId = node.id();
+            if (nodeId && (nodeId.startsWith('http') || nodeId.includes(':'))) {
+                window.location.href = nodeId + '/html';
+            }
+        });
+        
+        createLegend('hierarchy-container');
+        cy.fit();
+        cy.center();
+    });
+    
+    function createLegend(containerId) {
+        const container = document.getElementById(containerId);
+        const legend = document.createElement('div');
+        legend.style.cssText = 'position:absolute;top:10px;right:10px;background:rgba(255,255,255,0.9);padding:8px;border-radius:4px;border:1px solid #ccc;font-size:11px;z-index:10';
+        legend.setAttribute('role', 'region');
+        legend.setAttribute('aria-label', 'Graph legend');
+        legend.innerHTML = '<div style="font-weight:bold;margin-bottom:5px">Legend</div>' +
+            '<div style="display:flex;align-items:center;margin-bottom:3px"><div style="width:12px;height:12px;background:#184678;border-radius:3px;margin-right:5px"></div><div>Current Property</div></div>' +
+            '<div style="display:flex;align-items:center;margin-bottom:3px"><div style="width:12px;height:12px;background:#fff;border:1px solid #184678;border-radius:3px;margin-right:5px"></div><div>Parent Properties</div></div>' +
+            '<div style="display:flex;align-items:center;margin-bottom:3px"><div style="width:12px;height:12px;background:#fff;border:1px solid #29A35A;border-radius:3px;margin-right:5px"></div><div>Child Properties</div></div>' +
+            '<div style="display:flex;align-items:center;margin-bottom:3px"><div style="width:12px;height:12px;background:#f0fdfa;border:1px solid #0d9488;border-radius:3px;margin-right:5px"></div><div>Domain Classes</div></div>' +
+            '<div style="display:flex;align-items:center;margin-bottom:3px"><div style="width:12px;height:12px;background:#fff7ed;border:1px solid #ea580c;border-radius:3px;margin-right:5px"></div><div>Range Classes</div></div>' +
+            '<div style="display:flex;align-items:center;margin-bottom:3px"><div style="width:12px;height:12px;background:#faf5ff;border:1px solid #9333ea;border-radius:3px;margin-right:5px"></div><div>Inverse Property</div></div>';
+        container.appendChild(legend);
+    }
+</script>
+{% endblock %}

--- a/folio_api/templates/jinja2/properties/tree.html
+++ b/folio_api/templates/jinja2/properties/tree.html
@@ -1,0 +1,366 @@
+{% extends "layouts/base.html" %}
+
+{% block title %}FOLIO Property Explorer{% endblock %}
+
+{% block meta_description %}Interactive explorer for FOLIO OWL object properties{% endblock %}
+{% block meta_keywords %}legal, ontology, standard, open, information, properties, tree, explorer{% endblock %}
+
+{% block header_title %}FOLIO Property Explorer{% endblock %}
+{% block header_subtitle %}Navigate the FOLIO object property hierarchy{% endblock %}
+
+{% block header %}
+<header class="bg-[--color-primary] py-6 text-white">
+    <div class="container mx-auto px-4">
+        <div class="flex justify-between items-start">
+            <div>
+                <h1 class="text-3xl font-bold">FOLIO Property Explorer</h1>
+            </div>
+            <div class="hidden md:block header-buttons">
+                <a href="https://openlegalstandard.org/" target="_blank" class="inline-block bg-white text-[--color-primary] font-semibold px-4 py-2 rounded hover:bg-opacity-90 transition-colors duration-200 mr-2">FOLIO Website</a>
+                <a href="https://openlegalstandard.org/education/" target="_blank" class="inline-block bg-transparent text-white border border-white font-semibold px-4 py-2 rounded hover:bg-white hover:bg-opacity-10 transition-colors duration-200">Learn More</a>
+            </div>
+        </div>
+    </div>
+</header>
+{% endblock %}
+
+{% block extra_head %}
+<style>
+    .children-container {
+        border-left: 1px solid rgba(209, 213, 219, 0.7);
+        margin-left: 6px;
+        padding-left: 14px;
+    }
+    .tree-node { margin: 1px 0; }
+    .taxonomy-root-list > .tree-node > .node-content {
+        background-color: rgba(241, 245, 249, 0.7);
+        border-left: 3px solid var(--color-primary, rgb(24, 70, 120));
+        font-weight: 600;
+        padding-left: 6px;
+        margin-bottom: 2px;
+    }
+    .taxonomy-root-list > .tree-node > .children-container > .tree-node > .node-content {
+        font-weight: 500;
+        border-bottom: 1px solid rgba(209, 213, 219, 0.5);
+    }
+    .taxonomy-root-list > .tree-node > .children-container > .tree-node > .children-container > .tree-node > .node-content {
+        font-weight: normal;
+        font-size: 0.93rem;
+    }
+    .node-content {
+        padding: 3px 8px;
+        border-bottom: 1px solid rgba(229, 231, 235, 0.3);
+        line-height: 1.2;
+        font-size: 0.95rem;
+    }
+    .leaf-indicator {
+        width: 20px;
+        height: 20px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        margin-right: 4px;
+    }
+    .tree-node-highlighted > .node-content {
+        background-color: var(--color-primary, rgb(24, 70, 120)) !important;
+        color: white !important;
+        border-bottom-color: transparent !important;
+        border-left-color: transparent !important;
+    }
+    .tree-node-highlighted .node-label span.bg-blue-100 {
+        background-color: rgba(229, 231, 235, 0.7);
+        padding: 0 2px;
+        border-radius: 2px;
+        font-weight: bold;
+        color: var(--color-primary, rgb(24, 70, 120));
+    }
+    .children-container .tree-node:not(.selected):not(.tree-node-highlighted):not(.tree-node-match) > .node-content {
+        background-color: white;
+        color: var(--color-text-default, rgb(16, 16, 16));
+    }
+
+    /* Split-pane drag handle */
+    .split-handle {
+        width: 6px;
+        cursor: col-resize;
+        background: transparent;
+        flex-shrink: 0;
+        position: relative;
+        z-index: 10;
+        transition: background-color 0.15s;
+    }
+    .split-handle::after {
+        content: '';
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: 2px;
+        height: 32px;
+        border-radius: 1px;
+        background-color: #d1d5db;
+        transition: background-color 0.15s, height 0.15s;
+    }
+    .split-handle:hover {
+        background-color: rgba(59, 130, 246, 0.08);
+    }
+    .split-handle:hover::after {
+        background-color: #3b82f6;
+        height: 48px;
+    }
+    @media (max-width: 767px) {
+        .split-handle { display: none; }
+    }
+</style>
+{% endblock %}
+
+{% block navbar %}
+<div class="bg-white border-b mb-0 pb-0">
+    <div class="container mx-auto px-2 py-1">
+        <div class="flex flex-wrap gap-2"></div>
+    </div>
+</div>
+{% endblock %}
+
+{% block content %}
+<div class="flex flex-col md:flex-row tree-explorer-container bg-white rounded-lg shadow-md overflow-hidden -mx-4 mt-0" style="min-height: calc(85vh - 110px);">
+    <!-- Tree Panel -->
+    <div id="tree-container" class="w-full md:w-1/3 lg:w-1/4 p-2 md:h-[calc(85vh-110px)] md:overflow-hidden flex flex-col">
+        <div class="flex justify-between items-center mb-1">
+            <h2 class="text-lg font-semibold text-[--color-primary]">Property Tree</h2>
+            <a href="/properties/browse" class="text-xs text-[--color-primary] hover:underline">Switch to Browse View</a>
+        </div>
+        <div class="mb-1 sticky top-0 z-10 bg-white">
+            <div class="relative search-container">
+                <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
+                    <svg class="w-4 h-4 text-gray-500" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
+                    </svg>
+                </div>
+                <input type="search" id="taxonomy-search-input" class="block w-full py-1 px-2 ps-10 pe-14 text-sm border border-gray-300 rounded-lg focus:ring-blue-500 focus:border-blue-500" placeholder="Search properties...">
+                <button type="button" id="taxonomy-search-button" class="absolute inset-y-0 end-0 flex items-center pe-3 text-blue-600 hover:text-blue-800">
+                    <svg class="w-4 h-4" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+                        <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
+                    </svg>
+                </button>
+            </div>
+        </div>
+        <div class="tree-controls mb-1 flex flex-col space-y-0.5">
+            <div class="flex space-x-2">
+                <button id="expand-all-tree" class="text-xs bg-gray-200 hover:bg-gray-300 px-2 py-0.5 rounded" onclick="expandAllNodes()">Expand All</button>
+                <button id="collapse-all-tree" class="text-xs bg-gray-200 hover:bg-gray-300 px-2 py-0.5 rounded" onclick="collapseAllNodes()">Collapse All</button>
+            </div>
+            <div class="text-xs text-gray-500 italic">Tip: Double-click, press Space key, or click the arrow to expand/collapse</div>
+        </div>
+        <div id="taxonomy-tree" class="overflow-y-auto flex-grow border border-gray-100 rounded p-2" style="max-height: calc(85vh - 110px);"></div>
+    </div>
+    
+    <!-- Detail Panel -->
+    <div id="detail-container" class="w-full md:w-2/3 lg:w-3/4 p-3 bg-gray-50 max-w-full md:h-[calc(85vh-110px)] flex flex-col overflow-y-auto">
+        <div id="class-details">
+            <div class="flex items-center justify-center h-full text-gray-500">
+                <div class="text-center">
+                    <svg class="w-16 h-16 mx-auto text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+                    </svg>
+                    <h3 class="mt-2 text-xl font-medium">Select a property</h3>
+                    <p class="mt-1">Choose a property from the tree to view its details</p>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    {{ typeahead_js_source|safe }}
+</script>
+<script src="/static/js/split_pane.js"></script>
+<script src="/static/js/property_tree.js"></script>
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        // Initialize split pane resizer
+        if (typeof initSplitPane === 'function') {
+            initSplitPane({ storageKey: 'folio-property-split', defaultPct: 25 });
+        }
+
+        if (typeof initializeTree === 'function') {
+            initializeTree();
+        }
+        if (typeof setupTreeControls === 'function') {
+            setupTreeControls();
+        }
+        if (typeof setupHistoryNavigation === 'function') {
+            setupHistoryNavigation();
+        }
+        
+        const taxonomySearchInput = document.getElementById('taxonomy-search-input');
+        const taxonomySearchButton = document.getElementById('taxonomy-search-button');
+        
+        if (taxonomySearchInput && taxonomySearchButton) {
+            function performTaxonomySearch() {
+                const query = taxonomySearchInput.value;
+                if (query && query.length >= 2) {
+                    resetTreeSearch();
+                    searchTreeDirect(query);
+                    setTimeout(function() {
+                        const highlighted = document.querySelectorAll('.tree-node-highlighted');
+                        if (highlighted.length > 0) {
+                            const nodeId = highlighted[0].dataset.id;
+                            loadClassDetails(nodeId);
+                        }
+                    }, 100);
+                } else if (query.length > 0 && query.length < 2) {
+                    alert('Please enter at least 2 characters for search');
+                } else {
+                    resetTreeSearch();
+                }
+            }
+            
+            taxonomySearchButton.addEventListener('click', function() { performTaxonomySearch(); });
+            taxonomySearchInput.addEventListener('keydown', function(e) {
+                if (e.key === 'Enter') { e.preventDefault(); performTaxonomySearch(); }
+                if (e.key === 'Escape') { taxonomySearchInput.value = ''; resetTreeSearch(); }
+            });
+        }
+    });
+    
+    function searchTreeDirect(query) {
+        if (!query || query.length < 2) return;
+        resetTreeSearch();
+        const treeContainer = document.getElementById('taxonomy-tree');
+        if (treeContainer) {
+            treeContainer.innerHTML = '<div class="p-4 text-center"><div class="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600"></div><p class="mt-2 text-gray-600">Searching...</p></div>';
+        }
+        fetch('/properties/tree/search?query=' + encodeURIComponent(query))
+            .then(response => response.json())
+            .then(data => {
+                if (!data || !data.matches || data.matches.length === 0) {
+                    treeContainer.innerHTML = '<ul class="taxonomy-root-list"></ul>';
+                    initializeTree();
+                    return;
+                }
+                window.lastSearchResults = data.matches;
+                addFilterModeControls(data.matches.length, query);
+                renderFilteredTree(data.tree, query);
+                highlightAndSelectMatches(data.matches, query);
+            })
+            .catch(error => {
+                treeContainer.innerHTML = '<ul class="taxonomy-root-list"></ul>';
+                initializeTree();
+            });
+    }
+    
+    function renderFilteredTree(treeData, query) {
+        const treeContainer = document.getElementById('taxonomy-tree');
+        if (!treeContainer) return;
+        treeContainer.innerHTML = '<ul class="taxonomy-root-list"></ul>';
+        const rootList = treeContainer.querySelector('.taxonomy-root-list');
+        treeData.root_nodes.forEach(nodeId => { renderFilteredNode(nodeId, treeData, rootList, true); });
+        if (typeof applyTreeStyles === 'function') applyTreeStyles();
+        setupNodeClickHandlers();
+    }
+    
+    function renderFilteredNode(nodeId, treeData, container, isExpanded) {
+        const node = treeData.nodes[nodeId];
+        if (!node) return;
+        const hasChildren = node.children && node.children.length > 0;
+        const nodeClass = hasChildren ? (isExpanded ? 'has-children expanded' : 'has-children collapsed') : '';
+        const isMatch = node.is_match ? 'tree-node-match' : '';
+        const expandIcon = hasChildren ?
+            '<span class="expand-icon' + (isExpanded ? ' expanded' : '') + '"><svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 3 11 8 6 13"></polyline></svg></span>' :
+            '<span class="leaf-indicator"><span class="leaf-dot"></span></span>';
+        const li = document.createElement('li');
+        li.className = 'tree-node ' + nodeClass + ' ' + isMatch;
+        li.dataset.id = node.id;
+        li.innerHTML = '<div class="node-content">' + expandIcon + '<span class="node-label">' + node.label + '</span></div>' +
+            (hasChildren ? '<ul class="children-container" style="display:' + (isExpanded ? 'block' : 'none') + ';"></ul>' : '');
+        container.appendChild(li);
+        if (hasChildren && isExpanded) {
+            const childrenContainer = li.querySelector('.children-container');
+            node.children.forEach(childId => {
+                const childNode = treeData.nodes[childId];
+                const shouldExpand = childNode && (childNode.is_match || hasMatchDescendant(childId, treeData));
+                renderFilteredNode(childId, treeData, childrenContainer, shouldExpand);
+            });
+        }
+    }
+    
+    function hasMatchDescendant(nodeId, treeData) {
+        const node = treeData.nodes[nodeId];
+        if (!node) return false;
+        if (node.is_match) return true;
+        if (node.children) { for (const childId of node.children) { if (hasMatchDescendant(childId, treeData)) return true; } }
+        return false;
+    }
+    
+    function highlightAndSelectMatches(matches, query) {
+        const foundMatches = [];
+        document.querySelectorAll('.tree-node-match').forEach(node => {
+            node.classList.add('tree-node-highlighted');
+            const label = node.querySelector('.node-label');
+            if (label) label.innerHTML = highlightText(label.textContent, query);
+            foundMatches.push(node);
+        });
+        if (foundMatches.length > 0) {
+            const firstMatch = foundMatches[0];
+            loadClassDetails(firstMatch.dataset.id);
+            firstMatch.classList.add('selected');
+            firstMatch.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+    }
+    
+    function addFilterModeControls(resultCount, query) {
+        const existing = document.getElementById('filter-mode-controls');
+        if (existing) existing.remove();
+        const controls = document.createElement('div');
+        controls.id = 'filter-mode-controls';
+        controls.className = 'filter-mode-controls';
+        controls.innerHTML = '<div class="filter-info"><span id="filter-count" class="filter-count">' + resultCount + ' matches for "' + query + '"</span> <button id="clear-filter" class="clear-filter-btn">Clear Filter</button></div>';
+        const treeContainer = document.querySelector('#tree-container');
+        treeContainer.insertBefore(controls, treeContainer.firstChild);
+        document.getElementById('clear-filter').addEventListener('click', clearFilterMode);
+        addFilterModeStyles();
+    }
+    
+    function clearFilterMode() {
+        const controls = document.getElementById('filter-mode-controls');
+        if (controls) controls.remove();
+        const treeContainer = document.getElementById('taxonomy-tree');
+        if (!treeContainer) return;
+        treeContainer.innerHTML = '<ul class="taxonomy-root-list"></ul>';
+        initializeTree();
+    }
+    
+    function addFilterModeStyles() {
+        if (document.getElementById('filter-mode-styles')) return;
+        const style = document.createElement('style');
+        style.id = 'filter-mode-styles';
+        style.textContent = '.filter-mode-controls{background:rgba(24,70,120,0.1);border-radius:4px;padding:8px 12px;margin-bottom:12px;display:flex;justify-content:space-between;align-items:center}.filter-count{font-weight:500}.clear-filter-btn{background:#fff;border:1px solid var(--color-primary,rgb(24,70,120));padding:3px 8px;border-radius:4px;font-size:12px;cursor:pointer;color:var(--color-primary,rgb(24,70,120))}.clear-filter-btn:hover{background:rgba(24,70,120,0.1)}.tree-node-highlighted>.node-content,.tree-node-match>.node-content{background-color:var(--color-primary,rgb(24,70,120))!important;color:white!important;border-left-color:rgba(255,255,255,0.8)!important}.tree-node-match>.node-content{font-weight:500}';
+        document.head.appendChild(style);
+    }
+    
+    function resetTreeSearch() {
+        const isFilterMode = document.getElementById('filter-mode-controls') !== null;
+        if (isFilterMode) { clearFilterMode(); }
+        else {
+            document.querySelectorAll('.tree-node-highlighted').forEach(node => {
+                node.classList.remove('tree-node-highlighted');
+                const label = node.querySelector('.node-label');
+                if (label) label.textContent = label.textContent;
+            });
+        }
+    }
+    
+    function highlightText(text, query) {
+        const regex = new RegExp('(' + escapeRegEx(query) + ')', 'gi');
+        return text.replace(regex, '<span class="bg-blue-100">$1</span>');
+    }
+    
+    function escapeRegEx(string) {
+        return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    }
+</script>
+{% endblock %}

--- a/folio_api/templates/jinja2/taxonomy/class_detail.html
+++ b/folio_api/templates/jinja2/taxonomy/class_detail.html
@@ -125,9 +125,9 @@
                 <div class="flex flex-col">
                     <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-1">Alternative Labels</span>
                     {% if owl_class.alternative_labels %}
-                    <div class="flex flex-wrap gap-1 mt-1">
+                    <div class="flex flex-wrap gap-1.5 mt-1">
                         {% for label in owl_class.alternative_labels %}
-                        <span class="inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium bg-blue-50 text-blue-700">
+                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium bg-blue-50 text-blue-700">
                             {{ label }}
                         </span>
                         {% endfor %}

--- a/folio_api/templates/jinja2/taxonomy/class_detail.html
+++ b/folio_api/templates/jinja2/taxonomy/class_detail.html
@@ -83,7 +83,7 @@
     <section class="card animate-fade-in border-t-4 border-[--color-primary]">
         <div class="flex justify-between items-start">
             <div>
-                <h3 class="text-xl font-semibold mb-2 text-[--color-primary]">Identification</h3>
+                <h3 class="text-2xl font-semibold mb-2 text-[--color-primary]">{{ owl_class.label or "Unnamed Class" }}</h3>
                 <div class="flex flex-col sm:flex-row sm:items-center text-gray-500 text-sm mb-4">
                     <span class="font-medium mb-1 sm:mb-0 sm:mr-1.5 flex-shrink-0">IRI:</span>
                     <div class="overflow-hidden flex-1 min-w-0 mb-1 sm:mb-0 sm:mr-2">
@@ -112,23 +112,17 @@
         </div>
         
         <div class="bg-gray-50 rounded-lg p-4 mt-4">
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <div class="flex flex-col">
-                    <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-1">Label</span>
-                    <span class="text-gray-800 font-medium">{{ owl_class.label or "N/A" }}</span>
-                </div>
-                
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div class="flex flex-col">
                     <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-1">Preferred Label</span>
-                    <span class="text-gray-800">{{ owl_class.preferred_label or "N/A" }}</span>
+                    {% if owl_class.preferred_label %}
+                    <span class="text-gray-800">{{ owl_class.preferred_label }}</span>
+                    {% else %}
+                    <span class="text-gray-400 italic">N/A</span>
+                    {% endif %}
                 </div>
-                
+
                 <div class="flex flex-col">
-                    <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-1">Identifier</span>
-                    <span class="text-gray-800 font-mono text-sm">{{ owl_class.identifier or "N/A" }}</span>
-                </div>
-                
-                <div class="md:col-span-3">
                     <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-1">Alternative Labels</span>
                     {% if owl_class.alternative_labels %}
                     <div class="flex flex-wrap gap-1 mt-1">
@@ -139,13 +133,13 @@
                         {% endfor %}
                     </div>
                     {% else %}
-                    <p class="text-gray-700">None</p>
+                    <p class="text-gray-400 italic">None</p>
                     {% endif %}
                 </div>
             </div>
         </div>
     </section>
-    
+
     <!-- Definition and Examples -->
     <section class="card animate-fade-in border-t-4 border-emerald-500">
         <div class="flex items-start mb-4">
@@ -193,7 +187,7 @@
                     <svg class="w-4 h-4 mr-2 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 10l7-7m0 0l7 7m-7-7v18" />
                     </svg>
-                    <p class="text-gray-700 text-sm font-medium uppercase tracking-wide">Sub Class Of</p>
+                    <p class="text-gray-700 text-sm font-medium uppercase tracking-wide">Parent(s)</p>
                 </div>
                 <ul class="list-none space-y-2">
                     {% if owl_class.sub_class_of %}
@@ -210,7 +204,7 @@
                     {% else %}
                     <li class="flex items-center">
                         <span class="text-gray-400 mr-2">•</span>
-                        <span class="text-gray-500 italic">None</span>
+                        <span class="text-gray-400 italic">None</span>
                     </li>
                     {% endif %}
                 </ul>
@@ -223,7 +217,11 @@
                     </svg>
                     <p class="text-gray-700 text-sm font-medium uppercase tracking-wide">Is Defined By</p>
                 </div>
-                <p class="text-gray-800 ml-6">{{ owl_class.is_defined_by or "N/A" }}</p>
+                {% if owl_class.is_defined_by %}
+                <p class="text-gray-800 ml-6">{{ owl_class.is_defined_by }}</p>
+                {% else %}
+                <p class="text-gray-400 italic ml-6">N/A</p>
+                {% endif %}
                 
                 <div class="flex items-center mb-3 mt-4">
                     <svg class="w-4 h-4 mr-2 text-amber-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -261,7 +259,7 @@
                     {% endfor %}
                 </ul>
                 {% else %}
-                <p class="text-gray-500 italic ml-6">None</p>
+                <p class="text-gray-400 italic ml-6">None</p>
                 {% endif %}
             </div>
         </div>
@@ -272,7 +270,7 @@
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 14l-7 7m0 0l-7-7m7 7V3" />
                 </svg>
                 <p class="text-gray-700 text-sm font-medium uppercase tracking-wide">
-                    Parent Class Of 
+                    Children 
                     <span class="inline-flex items-center justify-center ml-2 bg-green-100 text-green-800 px-2 py-0.5 rounded-full text-xs">
                         {{ owl_class.parent_class_of|length if owl_class.parent_class_of else 0 }}
                     </span>
@@ -294,7 +292,7 @@
                     {% else %}
                     <li class="flex items-center">
                         <span class="text-gray-400 mr-2">•</span>
-                        <span class="text-gray-500 italic">None</span>
+                        <span class="text-gray-400 italic">None</span>
                     </li>
                     {% endif %}
                 </ul>
@@ -469,11 +467,19 @@
                 <div class="space-y-4">
                     <div class="p-3 bg-white rounded border border-gray-100">
                         <p class="text-gray-700 text-xs font-medium uppercase tracking-wide mb-1">Comment</p>
-                        <p class="text-gray-800">{{ owl_class.comment or "None" }}</p>
+                        {% if owl_class.comment %}
+                        <p class="text-gray-800">{{ owl_class.comment }}</p>
+                        {% else %}
+                        <p class="text-gray-400 italic">None</p>
+                        {% endif %}
                     </div>
                     <div class="p-3 bg-white rounded border border-gray-100">
                         <p class="text-gray-700 text-xs font-medium uppercase tracking-wide mb-1">Description</p>
-                        <p class="text-gray-800">{{ owl_class.description or "None" }}</p>
+                        {% if owl_class.description %}
+                        <p class="text-gray-800">{{ owl_class.description }}</p>
+                        {% else %}
+                        <p class="text-gray-400 italic">None</p>
+                        {% endif %}
                     </div>
                     <div class="p-3 bg-white rounded border border-gray-100">
                         <p class="text-gray-700 text-xs font-medium uppercase tracking-wide mb-1">Notes</p>
@@ -488,7 +494,7 @@
                             {% else %}
                             <li class="flex">
                                 <span class="text-gray-400 mr-2">•</span>
-                                <span class="text-gray-500 italic">None</span>
+                                <span class="text-gray-400 italic">None</span>
                             </li>
                             {% endif %}
                         </ul>
@@ -503,14 +509,30 @@
                     </svg>
                     <h4 class="text-lg font-medium text-[--color-primary]">Editorial Information</h4>
                 </div>
-                <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
                     <div class="p-3 bg-white rounded border border-gray-100">
                         <p class="text-gray-700 text-xs font-medium uppercase tracking-wide mb-1">History Note</p>
-                        <p class="text-gray-800">{{ owl_class.history_note or "None" }}</p>
+                        {% if owl_class.history_note %}
+                        <p class="text-gray-800">{{ owl_class.history_note }}</p>
+                        {% else %}
+                        <p class="text-gray-400 italic">None</p>
+                        {% endif %}
                     </div>
                     <div class="p-3 bg-white rounded border border-gray-100">
                         <p class="text-gray-700 text-xs font-medium uppercase tracking-wide mb-1">Editorial Note</p>
-                        <p class="text-gray-800">{{ owl_class.editorial_note or "None" }}</p>
+                        {% if owl_class.editorial_note %}
+                        <p class="text-gray-800">{{ owl_class.editorial_note }}</p>
+                        {% else %}
+                        <p class="text-gray-400 italic">None</p>
+                        {% endif %}
+                    </div>
+                    <div class="p-3 bg-white rounded border border-gray-100">
+                        <p class="text-gray-700 text-xs font-medium uppercase tracking-wide mb-1">Identifier</p>
+                        {% if owl_class.identifier %}
+                        <p class="text-gray-800 font-mono text-sm">{{ owl_class.identifier }}</p>
+                        {% else %}
+                        <p class="text-gray-400 italic">N/A</p>
+                        {% endif %}
                     </div>
                     <div class="p-3 bg-white rounded border border-gray-100">
                         <p class="text-gray-700 text-xs font-medium uppercase tracking-wide mb-1">Deprecated</p>

--- a/folio_api/templates/jinja2/taxonomy/class_detail.html
+++ b/folio_api/templates/jinja2/taxonomy/class_detail.html
@@ -382,14 +382,14 @@
             </svg>
             <h3 class="text-xl font-semibold text-[--color-primary]">Translations</h3>
         </div>
-        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
             {% for language, translation in owl_class.translations.items() %}
-            <div class="bg-indigo-50 p-4 rounded-lg">
-                <div class="flex items-center mb-2">
+            <div class="bg-indigo-50 px-4 py-2 rounded-lg">
+                <div class="flex items-center">
                     {% set language_lower = language|lower %}
                     {% set language_code = language_lower[:2] %}
                     {% set lang_flags = {
-                        "en": "🇬🇧", "en-gb": "🇬🇧", "en-us": "🇺🇸", "en-ca": "🇨🇦", "en-au": "🇦🇺", "en-nz": "🇳🇿", 
+                        "en": "🇬🇧", "en-gb": "🇬🇧", "en-us": "🇺🇸", "en-ca": "🇨🇦", "en-au": "🇦🇺", "en-nz": "🇳🇿",
                         "de": "🇩🇪", "de-de": "🇩🇪", "de-at": "🇦🇹", "de-ch": "🇨🇭",
                         "fr": "🇫🇷", "fr-fr": "🇫🇷", "fr-ca": "🇨🇦", "fr-ch": "🇨🇭", "fr-be": "🇧🇪",
                         "es": "🇪🇸", "es-es": "🇪🇸", "es-mx": "🇲🇽", "es-ar": "🇦🇷", "es-co": "🇨🇴",
@@ -403,15 +403,15 @@
                         "ko": "🇰🇷", "ko-kr": "🇰🇷",
                         "hi": "🇮🇳", "hi-in": "🇮🇳",
                         "ar": "🇸🇦", "ar-sa": "🇸🇦", "ar-eg": "🇪🇬", "ar-dz": "🇩🇿",
-                        "he": "🇮🇱", "he-il": "🇮🇱", 
+                        "he": "🇮🇱", "he-il": "🇮🇱",
                         "th": "🇹🇭", "vi": "🇻🇳"
                     } %}
-                    <span class="inline-block mr-2 text-xl" title="{{ language }}">
+                    <span class="inline-block mr-2 text-lg" title="{{ language }}">
                         {{ lang_flags.get(language_lower, lang_flags.get(language_code, "🌐")) }}
                     </span>
-                    <p class="text-indigo-700 text-sm font-medium uppercase tracking-wide">{{ language }}</p>
+                    <span class="text-indigo-700 font-mono text-sm w-12 flex-shrink-0">{{ language }}</span>
+                    <span class="text-gray-700 italic ml-2">{{ translation }}</span>
                 </div>
-                <p class="mt-1 text-gray-700">{{ translation }}</p>
             </div>
             {% endfor %}
         </div>

--- a/folio_api/templates/jinja2/taxonomy/class_detail.html
+++ b/folio_api/templates/jinja2/taxonomy/class_detail.html
@@ -302,6 +302,77 @@
         </div>
     </section>
     
+    <!-- Related Object Properties -->
+    {% if domain_properties or range_properties %}
+    <section class="card animate-fade-in border-t-4 border-teal-500">
+        <div class="flex items-start mb-4">
+            <svg class="w-5 h-5 mt-1 mr-2 text-teal-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
+            </svg>
+            <h3 class="text-xl font-semibold text-[--color-primary]">Related Object Properties</h3>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+            {% if domain_properties %}
+            <div class="bg-teal-50 rounded-lg p-4">
+                <div class="flex items-center mb-3">
+                    <svg class="w-4 h-4 mr-2 text-teal-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                    </svg>
+                    <p class="text-gray-700 text-sm font-medium uppercase tracking-wide">
+                        Properties with this class as Domain
+                        <span class="inline-flex items-center justify-center ml-2 bg-teal-100 text-teal-800 px-2 py-0.5 rounded-full text-xs">
+                            {{ domain_properties|length }}
+                        </span>
+                    </p>
+                </div>
+                <div class="max-h-60 overflow-y-auto">
+                    <ul class="list-none space-y-2">
+                        {# INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged #}
+                        {% for prop in domain_properties %}
+                        <li class="flex items-center">
+                            <span class="text-teal-500 mr-2">•</span>
+                            <a class="text-teal-700 hover:text-teal-900 hover:underline transition-colors duration-150" href="{{ prop.iri }}/html">
+                                {{ prop.label|strip_folio_prefix }}
+                            </a>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+            {% endif %}
+
+            {% if range_properties %}
+            <div class="bg-orange-50 rounded-lg p-4">
+                <div class="flex items-center mb-3">
+                    <svg class="w-4 h-4 mr-2 text-orange-600" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16l-4-4m0 0l4-4m-4 4h18" />
+                    </svg>
+                    <p class="text-gray-700 text-sm font-medium uppercase tracking-wide">
+                        Properties with this class as Range
+                        <span class="inline-flex items-center justify-center ml-2 bg-orange-100 text-orange-800 px-2 py-0.5 rounded-full text-xs">
+                            {{ range_properties|length }}
+                        </span>
+                    </p>
+                </div>
+                <div class="max-h-60 overflow-y-auto">
+                    <ul class="list-none space-y-2">
+                        {% for prop in range_properties %}
+                        <li class="flex items-center">
+                            <span class="text-orange-500 mr-2">•</span>
+                            <a class="text-orange-700 hover:text-orange-900 hover:underline transition-colors duration-150" href="{{ prop.iri }}/html">
+                                {{ prop.label|strip_folio_prefix }}
+                            </a>
+                        </li>
+                        {% endfor %}
+                    </ul>
+                </div>
+            </div>
+            {% endif %}
+        </div>
+    </section>
+    {% endif %}
+
     <!-- Translations -->
     {% if owl_class.translations %}
     <section class="card animate-fade-in border-t-4 border-indigo-500">

--- a/folio_api/templates/jinja2/taxonomy/tree.html
+++ b/folio_api/templates/jinja2/taxonomy/tree.html
@@ -67,9 +67,13 @@
     }
     
     .leaf-indicator {
-        flex: 0 0 8px;
-        min-width: 8px;
-        aspect-ratio: 1 / 1;
+        width: 20px;
+        height: 20px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        flex-shrink: 0;
+        margin-right: 4px;
     }
     
     /* Tree search highlight styles */
@@ -92,6 +96,39 @@
     .children-container .tree-node:not(.selected):not(.tree-node-highlighted):not(.tree-node-match) > .node-content {
         background-color: white;
         color: var(--color-text-default, rgb(16, 16, 16));
+    }
+
+    /* Split-pane drag handle */
+    .split-handle {
+        width: 6px;
+        cursor: col-resize;
+        background: transparent;
+        flex-shrink: 0;
+        position: relative;
+        z-index: 10;
+        transition: background-color 0.15s;
+    }
+    .split-handle::after {
+        content: '';
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        width: 2px;
+        height: 32px;
+        border-radius: 1px;
+        background-color: #d1d5db;
+        transition: background-color 0.15s, height 0.15s;
+    }
+    .split-handle:hover {
+        background-color: rgba(59, 130, 246, 0.08);
+    }
+    .split-handle:hover::after {
+        background-color: #3b82f6;
+        height: 48px;
+    }
+    @media (max-width: 767px) {
+        .split-handle { display: none; }
     }
 </style>
 {% endblock %}
@@ -159,15 +196,21 @@
     // Re-initialize the original typeahead search in the header
     {{ typeahead_js_source|safe }}
 </script>
+<script src="/static/js/split_pane.js"></script>
 <script src="/static/js/taxonomy_tree.js"></script>
 <script>
     // Initialize tree first without TypeaheadJS
     document.addEventListener('DOMContentLoaded', function() {
+        // Initialize split pane resizer
+        if (typeof initSplitPane === 'function') {
+            initSplitPane({ storageKey: 'folio-taxonomy-split', defaultPct: 25 });
+        }
+
         // Initialize the tree immediately
         if (typeof initializeTree === 'function') {
             initializeTree();
         }
-        
+
         // Set up tree controls
         if (typeof setupTreeControls === 'function') {
             setupTreeControls();
@@ -320,9 +363,9 @@
         const nodeClass = hasChildren ? 
             (isExpanded ? 'has-children expanded' : 'has-children collapsed') : '';
         const isMatch = node.is_match ? 'tree-node-match' : '';
-        const expandIcon = hasChildren ? 
-            `<span class="expand-icon mr-1" style="font-size: 24px; line-height: 16px; display: inline-flex; align-items: center; vertical-align: middle; position: relative; top: -2px;">${isExpanded ? '▾' : '▸'}</span>` : 
-            '<span class="leaf-indicator ml-1 mr-3 inline-flex shrink-0 items-center justify-center w-[8px] h-[8px] rounded-full bg-gray-200"></span>';
+        const expandIcon = hasChildren ?
+            `<span class="expand-icon${isExpanded ? ' expanded' : ''}"><svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 3 11 8 6 13"></polyline></svg></span>` :
+            '<span class="leaf-indicator"><span class="leaf-dot"></span></span>';
         
         const li = document.createElement('li');
         li.className = `tree-node ${nodeClass} ${isMatch}`;
@@ -507,9 +550,9 @@
             rootCategories.forEach(node => {
                 const hasChildren = node.children === true;
                 const nodeClass = hasChildren ? 'has-children collapsed' : '';
-                const expandIcon = hasChildren ? 
-                    '<span class="expand-icon mr-1" style="font-size: 24px; line-height: 16px; display: inline-flex; align-items: center; vertical-align: middle; position: relative; top: -2px;">▸</span>' : 
-                    '<span class="leaf-indicator ml-1 mr-3 inline-flex shrink-0 items-center justify-center w-[8px] h-[8px] rounded-full bg-gray-200"></span>';
+                const expandIcon = hasChildren ?
+                    '<span class="expand-icon"><svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 3 11 8 6 13"></polyline></svg></span>' :
+                    '<span class="leaf-indicator"><span class="leaf-dot"></span></span>';
                 
                 const li = document.createElement('li');
                 li.className = `tree-node ${nodeClass}`;


### PR DESCRIPTION
## Summary

- **Add OWL Object Property support with full UI parity**: New routes, templates, and JS for browsing and exploring properties (verbs) alongside existing classes (nouns) — includes property detail pages, tree explorer, browse view, search, and canonical HTML pages
- **Compact translation rows**: Translation sections now use a single-line layout for better density
- **Unified Ontology Explorer** (`/explore/tree`): Combines the separate class and property tree views into one page with two collapsible sections (NOUNS/VERBS), unified search across both, shared detail panel, and split-pane resizer. Old `/taxonomy/tree` and `/properties/tree` routes 301-redirect to the new view
- **Canonical HTML page improvements**: Replace "Identification" heading with the entity's `rdfs:label` (big and blue), remove redundant label field, move Identifier to Editorial Information section, rename "Sub Class Of" / "Parent Class Of" to "Parent(s)" / "Children", lighten N/A/None field values, move "Verb (Property)" tag to the right of the label, increase alternative label pill size to match preferred label
- **Consolidate navigation**: Replace separate Explore/Classes/Properties header buttons with a single "Browse" button linking to the unified explorer
- **Fix missing root classes**: Replace `FOLIO_TYPE_IRIS` dictionary with a curated `ROOT_CLASS_IRI_IDS` list of 24 root classes, adding three previously missing branches (Financial Concepts and Metrics, Industry and Market, Legal Use Cases) and excluding the sandbox class
- **Improve section header spacing**: Increase NOUNS/VERBS section header padding and font size for comfortable visual separation
- **Redesign search UI**: Rename heading to "Explore FOLIO", remove redundant left magnifying glass, add blue Search button with icon + text (always visible), Google-style Clear button inside the input that appears after filtering. Update placeholder to "Search FOLIO's nouns and verbs..."
- **Update explorer text**: Update tip text, change detail panel placeholder to "Search or Browse Items"
- **Match Search button to header color**: Use `--color-primary` instead of Tailwind blue
- **Hide internal/deprecated properties**: Filter out `utbms:activities`, `TR:SALI`, and `ZZZ:DEPRECATED PROPERTIES` (and their descendants) from the property tree using `HIDDEN_ROOT_PROPERTY_IRIS`
- **Exclude hidden properties from search**: Properties in hidden branches (`utbms:activities`, `TR:SALI`, `ZZZ:DEPRECATED PROPERTIES`) no longer appear in search results

## Test plan
- [ ] Visit `/explore/tree` — verify both NOUNS (24 classes) and VERBS sections load with roots
- [ ] Expand class and property nodes — verify lazy-loading and detail panel
- [ ] Search across both types — verify combined results and match count
- [ ] Verify Search button (blue, icon + "Search" text) is always visible to the right of the input
- [ ] Verify Search button color matches the header
- [ ] After searching, verify "Clear" button appears inside the input to the left of Search
- [ ] Click Clear — verify filter resets and Clear button hides
- [ ] Visit `/taxonomy/tree` and `/properties/tree` — verify 301 redirects to `/explore/tree`
- [ ] Visit a class canonical page (e.g. `/RDAy5MQTYwrACj2yao4MGbA/html`) — verify label heading, no redundant label, Identifier in Editorial section, Parent(s)/Children labels, light gray N/A values
- [ ] Visit a property canonical page (e.g. `/R55RwIpe6K1xGWsaee45Ch/html`) — verify "Verb (Property)" tag to the right, same styling improvements
- [ ] Verify header shows single "Browse" button across all pages
- [ ] Verify Financial Concepts and Metrics, Industry and Market, Legal Use Cases appear in tree
- [ ] Verify "ZZZ - SANDBOX" does NOT appear in tree
- [ ] Verify `utbms:activities`, `TR:SALI`, and `ZZZ:DEPRECATED PROPERTIES` do not appear in the VERBS section or in search results

🤖 Generated with [Claude Code](https://claude.com/claude-code)