### PR TITLE
fix: remove bash login shell and redundant commands from uv sync step

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -36,7 +36,7 @@ COPY --chown=app:app pyproject.toml ./
 COPY --chown=app:app README.md ./
 
 # Install dependencies
-RUN bash -l -c "uv sync --upgrade && uv venv && uv run python"
+RUN uv sync --upgrade
 
 # Copy application code
 COPY --chown=app:app folio_api folio_api


### PR DESCRIPTION
When we tried to run the `run.sh` script, it failed at the uv sync build step. The original command used `bash -l` (login shell), which sources profile files that don't exist in the Docker build environment, causing the build to error. 

`uv venv` and `uv run python` were also redundant, `uv sync` already creates the virtualenv, and running Python with no arguments serves no purpose in a build step.  