### PR TITLE
fix: Dockerfile build fails because uv sync runs before source is copied

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,12 +35,15 @@ RUN uv python install 3.12 \
 COPY --chown=app:app pyproject.toml ./
 COPY --chown=app:app README.md ./
 
-# Install dependencies
-RUN bash -l -c "uv sync --upgrade && uv venv && uv run python"
+# Install dependencies (without the project itself — code isn't copied yet)
+RUN uv sync --no-install-project --upgrade
 
 # Copy application code
 COPY --chown=app:app folio_api folio_api
 COPY --chown=app:app config.json.example ./config.json.example
+
+# Install the project package now that source is available
+RUN uv sync --upgrade
 
 # Set default port
 ENV PORT=8000


### PR DESCRIPTION
## Summary

- Fixes Dockerfile build failure where `uv venv` after `uv sync` tries to recreate an already-existing virtual environment
- Removes unnecessary `bash -l -c` wrapper and `uv run python` no-op
- Splits dependency install into two stages (`--no-install-project` before code copy, full sync after) for proper Docker layer caching

Closes #6

## Test plan

- [x] `docker build -f docker/Dockerfile -t folio-api:test .` succeeds
- [x] Step 14 installs 89 dependency packages (caching layer)
- [x] Step 17 installs only `folio-api==0.4.0` after source copy