### PR TITLE
feat: add structured logging config support

### DIFF
--- a/config.json
+++ b/config.json
@@ -23,9 +23,25 @@
     },
     "bind_ip": "0.0.0.0",
     "bind_port": 8000,
-    "cors_origins": [
-      "*"
-    ],
-    "log_level": "info"
+    "cors_origins": ["*"],
+    "logging": {
+      "version": 1,
+      "formatters": {
+        "json": {
+          "class": "pythonjsonlogger.json.JsonFormatter"
+        }
+      },
+      "handlers": {
+        "console": {
+          "class": "logging.StreamHandler",
+          "formatter": "json",
+          "stream": "ext://sys.stdout"
+        }
+      },
+      "root": {
+        "level": "INFO",
+        "handlers": ["console"]
+      }
+    }
   }
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -35,12 +35,15 @@ RUN uv python install 3.12 \
 COPY --chown=app:app pyproject.toml ./
 COPY --chown=app:app README.md ./
 
-# Install dependencies
-RUN bash -l -c "uv sync --upgrade && uv venv && uv run python"
+# Install dependencies (without the project itself — code isn't copied yet)
+RUN uv sync --no-install-project --upgrade
 
 # Copy application code
 COPY --chown=app:app folio_api folio_api
 COPY --chown=app:app config.json.example ./config.json.example
+
+# Install the project package now that source is available
+RUN uv sync --upgrade
 
 # Set default port
 ENV PORT=8000

--- a/folio_api/api.py
+++ b/folio_api/api.py
@@ -1,7 +1,9 @@
 """Main API module to define the FastAPI app and its configuration"""
 
 # imports
+import copy
 import logging
+import logging.config
 import os
 from collections import defaultdict
 from contextlib import asynccontextmanager
@@ -27,6 +29,8 @@ import folio_api.routes.explore
 import folio_api.routes.connections
 from folio_api.api_config import load_config
 
+_DEFAULT_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
 
 @asynccontextmanager
 async def lifespan_handler(app_instance: FastAPI):
@@ -40,28 +44,39 @@ async def lifespan_handler(app_instance: FastAPI):
     """
     # Initialize the FOLIO graph
     app_instance.state.config = load_config()
-
-    # get log level
-    log_level = {
-        "info": logging.INFO,
-        "debug": logging.DEBUG,
-        "warning": logging.WARNING,
-        "error": logging.ERROR,
-        "critical": logging.CRITICAL,
-    }.get(
-        app_instance.state.config.get("log_level", "info").lower().strip(), logging.INFO
-    )
-
-    # set up the logger at api.log
     app_instance.state.logger = logging.getLogger("folio_api")
-    app_instance.state.logger.setLevel(log_level)
-    log_handler = logging.FileHandler("api.log")
-    log_handler.setLevel(log_level)
-    log_formatter = logging.Formatter(
-        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    )
-    log_handler.setFormatter(log_formatter)
-    app_instance.state.logger.addHandler(log_handler)
+
+    # Use standard json logging config
+    api_config = app_instance.state.config["api"]
+    logging_config = api_config.get("logging")
+    if logging_config:
+        logging_config = copy.deepcopy(logging_config)
+        if "formatters" not in logging_config:
+            logging_config["formatters"] = {"default": {"format": _DEFAULT_LOG_FORMAT}}
+            for handler in logging_config.get("handlers", {}).values():
+                handler.setdefault("formatter", "default")
+        logging.config.dictConfig(logging_config)
+    else:
+        # get log level
+        log_level = {
+            "info": logging.INFO,
+            "debug": logging.DEBUG,
+            "warning": logging.WARNING,
+            "error": logging.ERROR,
+            "critical": logging.CRITICAL,
+        }.get(
+            api_config.get("log_level", "info").lower().strip(), logging.INFO
+        )
+
+        # set up the logger at api.log
+        app_instance.state.logger.setLevel(log_level)
+        log_handler = logging.FileHandler("api.log")
+        log_handler.setLevel(log_level)
+        log_formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+        log_handler.setFormatter(log_formatter)
+        app_instance.state.logger.addHandler(log_handler)
 
     # initialize the FOLIO instance
     app_instance.state.folio = initialize_folio(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "uvicorn>=0.30.6",
     "jinja2>=3.1.6",
     "folio-mcp>=0.2.0",
+    "python-json-logger>=3.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
Closes #9

## Summary

**Bug fix**: `log_level` was looked up at the config root (`config.get("log_level")`) but it lives under `config["api"]`, causing the setting to always silently default to `INFO` regardless of what was configured.

**Feature**: Adds an optional `"logging"` key under `config["api"]` that accepts any standard Python `logging.dictConfig`-compatible dict. If `"logging"` is present, it takes full precedence. If `"formatters"` is omitted from the logging config, a default formatter is injected automatically. If `"logging"` is absent entirely, the existing file-based fallback behavior is preserved unchanged.

Adds `python-json-logger` as a dependency and updates `config.json` to demonstrate minimal JSON stdout logging out of the box.

## Changes

- `folio_api/api.py`: fix `log_level` path; add `dictConfig` support with automatic default formatter injection
- `config.json`: update example to show minimal `dictConfig` usage with JSON stdout
- `pyproject.toml`: add `python-json-logger>=3.0.0` dependency

## Backwards compatibility

Fully backwards compatible — the existing `log_level` key and file handler fallback are preserved if no `"logging"` key is provided.

## Test plan

- [ ] Start server and verify JSON log lines appear on stdout
- [ ] Remove `"logging"` key from config and verify fallback branch respects `log_level`