### PR TITLE
fix: log_level config bug + stdlib dictConfig support

### DIFF
--- a/folio_api/api.py
+++ b/folio_api/api.py
@@ -56,7 +56,7 @@ async def lifespan_handler(app_instance: FastAPI):
     # simple FileHandler setup using the log_level key.
     api_config = app_instance.state.config["api"]
     logging_config = api_config.get("logging")
-    if logging_config:
+    if logging_config and "version" in logging_config:
         logging_config = copy.deepcopy(logging_config)
         if "formatters" not in logging_config:
             logging_config["formatters"] = {"default": {"format": _DEFAULT_LOG_FORMAT}}

--- a/folio_api/api.py
+++ b/folio_api/api.py
@@ -17,7 +17,13 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from folio import FOLIO
-from alea_llm_client import AnthropicModel, GoogleModel, GrokModel, OpenAIModel, VLLMModel
+from alea_llm_client import (
+    AnthropicModel,
+    GoogleModel,
+    GrokModel,
+    OpenAIModel,
+    VLLMModel,
+)
 
 # project imports
 import folio_api.routes.info
@@ -64,9 +70,7 @@ async def lifespan_handler(app_instance: FastAPI):
             "warning": logging.WARNING,
             "error": logging.ERROR,
             "critical": logging.CRITICAL,
-        }.get(
-            api_config.get("log_level", "info").lower().strip(), logging.INFO
-        )
+        }.get(api_config.get("log_level", "info").lower().strip(), logging.INFO)
 
         app_instance.state.logger.setLevel(log_level)
         log_handler = logging.FileHandler("api.log")
@@ -90,6 +94,7 @@ async def lifespan_handler(app_instance: FastAPI):
 
     # Share FOLIO instance with MCP server
     from folio_mcp.server import set_shared_folio
+
     set_shared_folio(app_instance.state.folio)
 
     # log it
@@ -141,7 +146,9 @@ def initialize_folio(folio_config: Dict[str, Any], llm_config: Dict[str, Any]) -
     llm_engine = llm_config.get("type", "openai").lower().strip()
     llm_model = llm_config.get("model", "gpt-5.1-mini").strip()
     llm_endpoint = llm_config.get("endpoint", None)
-    llm_api_key = llm_config.get("api_key", os.getenv(_API_KEY_ENV_VARS.get(llm_engine, "OPENAI_API_KEY")))
+    llm_api_key = llm_config.get(
+        "api_key", os.getenv(_API_KEY_ENV_VARS.get(llm_engine, "OPENAI_API_KEY"))
+    )
     llm_effort = llm_config.get("effort", None)
     llm_tier = llm_config.get("tier", None)
 
@@ -257,6 +264,7 @@ def get_app() -> FastAPI:
     # Remove this once https://github.com/alea-institute/FOLIO/pull/5 is merged and
     # folio-python is updated with human-readable rdfs:label values.
     from folio_api.rendering import strip_folio_prefix
+
     app_instance.state.templates.env.filters["strip_folio_prefix"] = strip_folio_prefix
 
     # Attach the routes
@@ -271,6 +279,7 @@ def get_app() -> FastAPI:
 
     # Mount FOLIO MCP server at /mcp
     from folio_mcp.server import mcp as folio_mcp_server
+
     app_instance.mount("/mcp", folio_mcp_server.streamable_http_app())
 
     return app_instance

--- a/folio_api/api.py
+++ b/folio_api/api.py
@@ -1,7 +1,9 @@
 """Main API module to define the FastAPI app and its configuration"""
 
 # imports
+import copy
 import logging
+import logging.config
 import os
 from collections import defaultdict
 from contextlib import asynccontextmanager
@@ -27,6 +29,8 @@ import folio_api.routes.explore
 import folio_api.routes.connections
 from folio_api.api_config import load_config
 
+_DEFAULT_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+
 
 @asynccontextmanager
 async def lifespan_handler(app_instance: FastAPI):
@@ -40,28 +44,36 @@ async def lifespan_handler(app_instance: FastAPI):
     """
     # Initialize the FOLIO graph
     app_instance.state.config = load_config()
-
-    # get log level
-    log_level = {
-        "info": logging.INFO,
-        "debug": logging.DEBUG,
-        "warning": logging.WARNING,
-        "error": logging.ERROR,
-        "critical": logging.CRITICAL,
-    }.get(
-        app_instance.state.config.get("log_level", "info").lower().strip(), logging.INFO
-    )
-
-    # set up the logger at api.log
     app_instance.state.logger = logging.getLogger("folio_api")
-    app_instance.state.logger.setLevel(log_level)
-    log_handler = logging.FileHandler("api.log")
-    log_handler.setLevel(log_level)
-    log_formatter = logging.Formatter(
-        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    )
-    log_handler.setFormatter(log_formatter)
-    app_instance.state.logger.addHandler(log_handler)
+
+    # Configure logging via dictConfig if provided, otherwise fall back to
+    # simple FileHandler setup using the log_level key.
+    api_config = app_instance.state.config["api"]
+    logging_config = api_config.get("logging")
+    if logging_config:
+        logging_config = copy.deepcopy(logging_config)
+        if "formatters" not in logging_config:
+            logging_config["formatters"] = {"default": {"format": _DEFAULT_LOG_FORMAT}}
+            for handler in logging_config.get("handlers", {}).values():
+                handler.setdefault("formatter", "default")
+        logging.config.dictConfig(logging_config)
+    else:
+        log_level = {
+            "info": logging.INFO,
+            "debug": logging.DEBUG,
+            "warning": logging.WARNING,
+            "error": logging.ERROR,
+            "critical": logging.CRITICAL,
+        }.get(
+            api_config.get("log_level", "info").lower().strip(), logging.INFO
+        )
+
+        app_instance.state.logger.setLevel(log_level)
+        log_handler = logging.FileHandler("api.log")
+        log_handler.setLevel(log_level)
+        log_formatter = logging.Formatter(_DEFAULT_LOG_FORMAT)
+        log_handler.setFormatter(log_formatter)
+        app_instance.state.logger.addHandler(log_handler)
 
     # initialize the FOLIO instance
     app_instance.state.folio = initialize_folio(


### PR DESCRIPTION
Closes #9 — supersedes #11

## Summary

- **Bug fix**: `log_level` was read from the config root (`config.get("log_level")`) but lives under `config["api"]`, causing it to always silently default to `INFO`
- **Feature**: Adds optional `"logging"` key under `config["api"]` that accepts any standard Python `logging.config.dictConfig`-compatible dict — no new dependencies required (pure stdlib)
- If `"formatters"` is omitted from the logging config, a default formatter is injected automatically
- If `"logging"` is absent, the existing `log_level` + FileHandler fallback is preserved unchanged

## Why not python-json-logger?

PR #11 added `python-json-logger` as a dependency. That package had a supply chain RCE vulnerability (CVE-2025-27607) in versions 3.2.0–3.2.1 and underwent a maintainer transfer in 2024. Since `dictConfig` is pure stdlib and users can bring their own formatter package if needed, the external dependency is unnecessary.

## Example: adding JSON logging (optional, user-supplied)

Users who want JSON structured logs can install any formatter package (e.g., `python-json-logger`, `structlog`) and reference it in their config:

```json
{
  "api": {
    "logging": {
      "version": 1,
      "formatters": {
        "json": { "class": "pythonjsonlogger.json.JsonFormatter" }
      },
      "handlers": {
        "console": {
          "class": "logging.StreamHandler",
          "formatter": "json",
          "stream": "ext://sys.stdout"
        }
      },
      "root": { "level": "INFO", "handlers": ["console"] }
    }
  }
}
```

## Test plan

- [ ] Start server with default config (`log_level` only) — verify `api.log` file logging works and respects configured level
- [ ] Add `"logging"` dictConfig block to config — verify it takes precedence
- [ ] Remove `"logging"` key — verify fallback to `log_level` + FileHandler

🤖 Generated with [Claude Code](https://claude.com/claude-code)