### PR TITLE
Exclude non-English translations from Alternative Labels panel

### DIFF
--- a/folio_api/api.py
+++ b/folio_api/api.py
@@ -263,9 +263,14 @@ def get_app() -> FastAPI:
     # INTERIM FIX: Register strip_folio_prefix Jinja2 filter for human-readable property labels.
     # Remove this once https://github.com/alea-institute/FOLIO/pull/5 is merged and
     # folio-python is updated with human-readable rdfs:label values.
-    from folio_api.rendering import strip_folio_prefix
+    from folio_api.rendering import english_alternative_labels, strip_folio_prefix
 
     app_instance.state.templates.env.filters["strip_folio_prefix"] = strip_folio_prefix
+    # Filter altLabels to exclude translation values — folio-python ≥0.3.5
+    # conflates translations into alternative_labels.
+    app_instance.state.templates.env.filters["english_alternative_labels"] = (
+        english_alternative_labels
+    )
 
     # Attach the routes
     app_instance.include_router(folio_api.routes.info.router)

--- a/folio_api/rendering/__init__.py
+++ b/folio_api/rendering/__init__.py
@@ -14,6 +14,7 @@ from folio_api.rendering.html_formatter import (
     get_property_neighbors,
     render_tailwind_html,
     strip_folio_prefix,
+    english_alternative_labels,
 )
 
 __all__ = [
@@ -25,4 +26,5 @@ __all__ = [
     "get_property_neighbors",
     "render_tailwind_html",
     "strip_folio_prefix",
+    "english_alternative_labels",
 ]

--- a/folio_api/rendering/html_formatter.py
+++ b/folio_api/rendering/html_formatter.py
@@ -24,6 +24,29 @@ def strip_folio_prefix(label: str) -> str:
     return label or ""
 
 
+def english_alternative_labels(obj) -> List[str]:
+    """Return the truly-English alternative labels for an OWL class or property.
+
+    folio-python ≥0.3.5 conflates non-English translations into the
+    `alternative_labels` list (alongside the dedicated `translations` dict).
+    Without filtering, the "Alternative Labels" UI redundantly shows
+    "Droit de la franchise", "Franchiserecht", etc. that are already in the
+    Translations panel.
+
+    Strict subtraction: drop any altLabel value present in translations.values()
+    (any language). Works on both raw OWL objects and the dict shape that
+    routes hand to templates.
+    """
+    if isinstance(obj, dict):
+        alt = obj.get("alternative_labels") or []
+        translations = obj.get("translations") or {}
+    else:
+        alt = getattr(obj, "alternative_labels", None) or []
+        translations = getattr(obj, "translations", None) or {}
+    translation_values = set(translations.values()) if translations else set()
+    return [a for a in alt if a not in translation_values]
+
+
 def format_label(owl_class: OWLClass) -> str:
     """
     Format the label of the class for display  in HTML.
@@ -39,9 +62,10 @@ def format_label(owl_class: OWLClass) -> str:
         return owl_class.preferred_label
     elif owl_class.label:
         return owl_class.label
-    elif owl_class.alternative_labels:
-        return owl_class.alternative_labels[0]
     else:
+        english_alts = english_alternative_labels(owl_class)
+        if english_alts:
+            return english_alts[0]
         return owl_class.iri
 
 
@@ -256,9 +280,10 @@ def format_property_label(prop: OWLObjectProperty) -> str:
         return strip_folio_prefix(prop.preferred_label)
     elif prop.label:
         return strip_folio_prefix(prop.label)
-    elif prop.alternative_labels:
-        return strip_folio_prefix(prop.alternative_labels[0])
     else:
+        english_alts = english_alternative_labels(prop)
+        if english_alts:
+            return strip_folio_prefix(english_alts[0])
         return prop.iri
 
 
@@ -581,7 +606,7 @@ def render_tailwind_html(
                         
                         <div>
                             <p class="text-gray-500 text-sm mb-1">Alternative Labels</p>
-                            <p>{", ".join(owl_class.alternative_labels) or "None"}</p>
+                            <p>{", ".join(english_alternative_labels(owl_class)) or "None"}</p>
                         </div>
                     </div>
                 </section>

--- a/folio_api/templates/jinja2/components/class_details.html
+++ b/folio_api/templates/jinja2/components/class_details.html
@@ -38,7 +38,7 @@
 <div class="grid grid-cols-1 xl:grid-cols-2 gap-6 w-full" style="width: 100%; max-width: 100%;" id="detail-grid">
     <!-- COLUMN 1 -->
     <!-- Labels section - Added at the top -->
-    {% if class_data.preferred_label or class_data.alternative_labels %}
+    {% if class_data.preferred_label or (class_data | english_alternative_labels) %}
     <section class="card animate-fade-in">
         <h4 class="text-lg font-medium text-[--color-primary] mb-3 flex items-center">
             <svg class="w-4 h-4 mr-2 text-purple-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -55,11 +55,12 @@
                 </div>
                 {% endif %}
                 
-                {% if class_data.alternative_labels %}
+                {% set english_alts = class_data | english_alternative_labels %}
+                {% if english_alts %}
                 <div>
                     <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-2 block">Alternative Labels</span>
                     <div class="flex flex-wrap gap-1">
-                        {% for label in class_data.alternative_labels %}
+                        {% for label in english_alts %}
                         <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium bg-purple-100 text-purple-800">
                             {{ label }}
                         </span>

--- a/folio_api/templates/jinja2/components/property_details.html
+++ b/folio_api/templates/jinja2/components/property_details.html
@@ -30,7 +30,8 @@
 
 <div class="grid grid-cols-1 xl:grid-cols-2 gap-6 w-full" style="width: 100%; max-width: 100%;" id="detail-grid">
     <!-- Labels section -->
-    {% if prop_data.preferred_label or prop_data.alternative_labels %}
+    {% set english_alts = prop_data | english_alternative_labels %}
+    {% if prop_data.preferred_label or english_alts %}
     <section class="card animate-fade-in">
         <h4 class="text-lg font-medium text-[--color-primary] mb-3 flex items-center">
             <svg class="w-4 h-4 mr-2 text-purple-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -46,11 +47,11 @@
                     <span class="text-gray-800 font-medium text-lg block">{{ prop_data.preferred_label|strip_folio_prefix }}</span>
                 </div>
                 {% endif %}
-                {% if prop_data.alternative_labels %}
+                {% if english_alts %}
                 <div>
                     <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-2 block">Alternative Labels</span>
                     <div class="flex flex-wrap gap-1">
-                        {% for label in prop_data.alternative_labels %}
+                        {% for label in english_alts %}
                         {# INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged #}
                         <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium bg-purple-100 text-purple-800">{{ label|strip_folio_prefix }}</span>
                         {% endfor %}

--- a/folio_api/templates/jinja2/properties/property_detail.html
+++ b/folio_api/templates/jinja2/properties/property_detail.html
@@ -83,9 +83,10 @@
                 </div>
                 <div class="flex flex-col">
                     <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-1">Alternative Labels</span>
-                    {% if prop.alternative_labels %}
+                    {% set english_alts = prop | english_alternative_labels %}
+                    {% if english_alts %}
                     <div class="flex flex-wrap gap-1.5 mt-1">
-                        {% for label in prop.alternative_labels %}
+                        {% for label in english_alts %}
                         {# INTERIM: strip_folio_prefix can be removed once FOLIO PR #5 is merged #}
                         <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium bg-blue-50 text-blue-700">{{ label|strip_folio_prefix }}</span>
                         {% endfor %}

--- a/folio_api/templates/jinja2/taxonomy/class_detail.html
+++ b/folio_api/templates/jinja2/taxonomy/class_detail.html
@@ -124,9 +124,10 @@
 
                 <div class="flex flex-col">
                     <span class="text-gray-500 text-xs font-medium uppercase tracking-wide mb-1">Alternative Labels</span>
-                    {% if owl_class.alternative_labels %}
+                    {% set english_alts = owl_class | english_alternative_labels %}
+                    {% if english_alts %}
                     <div class="flex flex-wrap gap-1.5 mt-1">
-                        {% for label in owl_class.alternative_labels %}
+                        {% for label in english_alts %}
                         <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-sm font-medium bg-blue-50 text-blue-700">
                             {{ label }}
                         </span>


### PR DESCRIPTION
## Summary

The "Alternative Labels" panel on class detail pages was rendering every entry from `OWLClass.alternative_labels` — which **folio-python ≥0.3.5 conflates with non-English translations** from `OWLClass.translations`. Users saw "Droit de la franchise", "Franchiserecht", "フランチャイズ法", etc. duplicated between the Alternative Labels panel and the dedicated Translations panel.

This PR insulates folio-api against the upstream conflation by filtering at the rendering layer.

## Root cause

It's an upstream regression in folio-python's parser, confirmed by direct version comparison:

| folio-python version | `alternative_labels` for Franchise Law (`RCzUXCcw0tXLGGdeAIx9Dx4`) |
|---|---|
| **0.3.0** (running on prod's old container) | `None` / empty ← clean separation |
| 0.3.5 | full 9-item list including French/German/Hebrew/Japanese translations |
| **0.3.6** (uv.lock pinned, what local & dev now run) | full list |

Prod was unaffected only because its container is ~4 weeks old, built when 0.3.0 was the latest available. The recent hotfix to `uv sync --frozen` (commit `5190bd8`) didn't introduce this — it just exposed the latent regression by ensuring builds use the locked 0.3.6.

## Fix

A small helper plus a Jinja2 filter — applied at every rendering surface, JSON API intentionally untouched.

### `folio_api/rendering/html_formatter.py` (new function)

```python
def english_alternative_labels(obj) -> List[str]:
    """Return the truly-English alternative labels for an OWL class or property.

    folio-python ≥0.3.5 conflates non-English translations into the
    `alternative_labels` list (alongside the dedicated `translations` dict).

    Strict subtraction: drop any altLabel value present in translations.values()
    (any language). Works on both raw OWL objects and the dict shape that
    routes hand to templates.
    """
    if isinstance(obj, dict):
        alt = obj.get("alternative_labels") or []
        translations = obj.get("translations") or {}
    else:
        alt = getattr(obj, "alternative_labels", None) or []
        translations = getattr(obj, "translations", None) or {}
    translation_values = set(translations.values()) if translations else set()
    return [a for a in alt if a not in translation_values]
```

### `folio_api/api.py`

Registers the helper as a Jinja2 filter alongside the existing `strip_folio_prefix`:

```python
app_instance.state.templates.env.filters["english_alternative_labels"] = (
    english_alternative_labels
)
```

### Templates (4)

Each guard + loop changed from `class_data.alternative_labels` to `class_data | english_alternative_labels`:

- `components/class_details.html` — AJAX detail panel in `/explore/tree`
- `components/property_details.html` — AJAX detail panel for properties
- `taxonomy/class_detail.html` — standalone `/{iri}/html` for classes
- `properties/property_detail.html` — standalone `/{iri}/html` for properties

### `rendering/html_formatter.py` (3 call sites)

- `format_label()` — fallback to first altLabel as label (now picks first *English* altLabel)
- `format_property_label()` — same for properties
- `render_tailwind_html()` — the rendered "Alternative Labels" line uses the filtered list

## Verification

Three test classes via `/taxonomy/class-details/<id>`:

| Class | Before fix (broken) | After fix |
|---|---|---|
| Actor / Player | 12 entries incl. "俳優 / プレイヤー", "Acteur / Joueur" | `['Actor', 'Player', 'Player Role']` |
| Agriculture Law | 12 entries | `['Agribusiness Law', 'Farm Law']` ← matches prod's current output |
| Franchise Law | 9 entries | `[]` — section hidden (no English synonyms exist) |

Same results from the standalone `/{iri}/html` route (different template, same filter).

## What this PR is *not*

- **Not a folio-python pin.** The upstream regression is real and worth filing against `alea-institute/folio-python`, but pinning `folio-python==0.3.0` in `pyproject.toml` would regress LLM features (commit `91ff9e0` deliberately bumped to `>=0.3.2` for the gpt-5.4 default). Filtering at our layer is version-agnostic.
- **Not a JSON API change.** `/{iri}/json`, `/{iri}/jsonld`, etc. still return whatever folio-python produces. Only display surfaces filter.
- **Not a search-relevance change.** Search still matches against the full alt-label list, so typing "Franchiserecht" still finds Franchise Law via translations.

## Files changed

```
folio_api/api.py                                      |  6 +++++-
folio_api/rendering/__init__.py                       |  2 ++
folio_api/rendering/html_formatter.py                 | 33 +++++++++++++++++++++++++++++----
folio_api/templates/jinja2/components/class_details.html        |  6 ++++--
folio_api/templates/jinja2/components/property_details.html     |  7 ++++---
folio_api/templates/jinja2/properties/property_detail.html      |  5 +++--
folio_api/templates/jinja2/taxonomy/class_detail.html           |  5 +++--
7 files changed, 52 insertions(+), 16 deletions(-)
```

## Test plan

- [ ] Visit `/explore/tree`, click **Franchise Law** — Alternative Labels section should be **hidden** (no English synonyms exist for this class)
- [ ] Click **Actor / Player** — Alternative Labels shows only `Actor, Player, Player Role`; non-English translations remain in the Translations panel
- [ ] Click **Agriculture Law** — matches prod: `Agribusiness Law, Farm Law` only
- [ ] Visit `/RCzUXCcw0tXLGGdeAIx9Dx4/html` directly — same filtering on the standalone page
- [ ] Visit any property page (e.g. `/R6qohvM786wjw0MNQJg9Dq/html`) — properties have no translations, so the filter is a no-op; verify nothing changes vs current
- [ ] Search for "Franchiserecht" via the typeahead — should still match Franchise Law (search index untouched)
- [ ] Hit `/RCzUXCcw0tXLGGdeAIx9Dx4` (JSON) — `alternative_labels` array should still be the full upstream list (API contract preserved)

## Follow-ups (separate PRs, not in scope here)

- File the upstream bug against `alea-institute/folio-python` for the alt_labels/translations conflation introduced between 0.3.0 and 0.3.5
- Consider committing `uv.lock` (currently gitignored) so future Docker builds don't silently shift folio-python versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)