### PR TITLE
fix(static): cache-bust assets so deploys don't serve stale JS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     environment:
       - PORT=${PORT:-8000}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - XAI_API_KEY=${XAI_API_KEY}
       - PYTHONPATH=/app
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${PORT:-8000}/info/health"]

--- a/docker/Caddyfile
+++ b/docker/Caddyfile
@@ -20,9 +20,28 @@ folio.openlegalstandard.org {
         # Remove the Server header
         -Server
     }
-    # Add rate limiting
-    @api {
-        path /search/* /taxonomy/*
+}
+
+soli.openlegalstandard.org {
+    encode gzip
+    reverse_proxy api:{$PORT}
+    tls {
+        protocols tls1.2 tls1.3
     }
-    rate_limit @api 100r/m
+    log {
+        output file /var/log/caddy/access.log
+        format json
+    }
+    header {
+        # Enable HTTP Strict Transport Security (HSTS)
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        # Enable Cross-Site Filter (XSS Protection)
+        X-XSS-Protection "1; mode=block"
+        # Disable clients from inferring the MIME type
+        X-Content-Type-Options "nosniff"
+        # Prevent clickjacking
+        X-Frame-Options "SAMEORIGIN"
+        # Remove the Server header
+        -Server
+    }
 }

--- a/folio_api/api.py
+++ b/folio_api/api.py
@@ -38,6 +38,42 @@ from folio_api.api_config import load_config
 _DEFAULT_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
 
+class CachedStaticFiles(StaticFiles):
+    """StaticFiles that sets an explicit ``Cache-Control`` header.
+
+    Without it, Starlette serves static assets with only ``ETag`` /
+    ``Last-Modified``, so browsers apply *heuristic* freshness and can keep
+    serving a stale ``.js``/``.css`` long after a deploy (this is exactly what
+    broke the Entity Graph for returning visitors: new HTML, but a cached old
+    ``unified_tree.js`` with no graph wiring). Paired with ``?v=`` cache-busting
+    on asset URLs, a deploy now changes the URL and browsers revalidate.
+    """
+
+    def file_response(self, *args: Any, **kwargs: Any):
+        response = super().file_response(*args, **kwargs)
+        response.headers.setdefault(
+            "Cache-Control", "public, max-age=3600, must-revalidate"
+        )
+        return response
+
+
+def _compute_asset_version(directory: Path) -> str:
+    """Cache-busting token = newest static-asset mtime (integer seconds).
+
+    Appended to asset URLs as ``?v=``; changes whenever any static file is
+    rebuilt/redeployed, so returning browsers fetch the new asset instead of a
+    stale cached copy.
+    """
+    try:
+        latest = max(
+            (p.stat().st_mtime for p in directory.rglob("*") if p.is_file()),
+            default=0.0,
+        )
+        return str(int(latest))
+    except Exception:
+        return "0"
+
+
 @asynccontextmanager
 async def lifespan_handler(app_instance: FastAPI):
     """Context manager to handle the lifespan events of the FastAPI app
@@ -263,7 +299,13 @@ def get_app() -> FastAPI:
                 "Failed to create static directory: %s" % static_dir
             ) from e
 
-    app_instance.mount("/static", StaticFiles(directory=static_dir), name="static")
+    # Cache-busting token derived from the newest static asset mtime; exposed to
+    # templates as `asset_version` and appended to asset URLs as `?v=`.
+    asset_version = _compute_asset_version(static_dir)
+
+    app_instance.mount(
+        "/static", CachedStaticFiles(directory=static_dir), name="static"
+    )
 
     # Initialize Jinja2 templates
     templates_dir = Path(__file__).parent / "templates" / "jinja2"
@@ -279,6 +321,9 @@ def get_app() -> FastAPI:
 
     # Store templates instance in app state
     app_instance.state.templates = Jinja2Templates(directory=templates_dir)
+
+    # Expose the cache-busting token to all templates (used as ?v= on assets).
+    app_instance.state.templates.env.globals["asset_version"] = asset_version
 
     # INTERIM FIX: Register strip_folio_prefix Jinja2 filter for human-readable property labels.
     # Remove this once https://github.com/alea-institute/FOLIO/pull/5 is merged and

--- a/folio_api/templates/jinja2/explore/tree.html
+++ b/folio_api/templates/jinja2/explore/tree.html
@@ -271,9 +271,9 @@
 <script>
     {{ typeahead_js_source|safe }}
 </script>
-<script src="/static/js/split_pane.js"></script>
-<script src="/static/js/unified_tree.js"></script>
-<script src="/static/js/entity_graph.js"></script>
+<script src="/static/js/split_pane.js?v={{ asset_version }}"></script>
+<script src="/static/js/unified_tree.js?v={{ asset_version }}"></script>
+<script src="/static/js/entity_graph.js?v={{ asset_version }}"></script>
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         if (typeof initSplitPane === 'function') {

--- a/folio_api/templates/jinja2/layouts/base.html
+++ b/folio_api/templates/jinja2/layouts/base.html
@@ -13,8 +13,8 @@
     <link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
     <link rel="preconnect" href="https://fonts.googleapis.com" crossorigin>
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="preload" href="/static/css/styles.css" as="style">
-    <link rel="preload" href="/static/js/copy_iri.js" as="script">
+    <link rel="preload" href="/static/css/styles.css?v={{ asset_version }}" as="style">
+    <link rel="preload" href="/static/js/copy_iri.js?v={{ asset_version }}" as="script">
     
     <!-- Critical scripts loaded with high priority -->
     <script src="https://cdn.tailwindcss.com?plugins=forms,typography,aspect-ratio"></script>
@@ -22,7 +22,7 @@
     <script src="/static/js/vendor/typeahead.bundle.min.js"></script>
     
     <!-- All styles -->
-    <link rel="stylesheet" href="/static/css/styles.css">
+    <link rel="stylesheet" href="/static/css/styles.css?v={{ asset_version }}">
     
     {% block extra_head %}{% endblock %}
     
@@ -65,7 +65,7 @@
     {% include "components/footer.html" %}
     
     <!-- Global Scripts -->
-    <script src="/static/js/copy_iri.js"></script>
+    <script src="/static/js/copy_iri.js?v={{ asset_version }}"></script>
     
     <!-- Page specific scripts -->
     {% block scripts %}{% endblock %}

--- a/tests/test_static_cache.py
+++ b/tests/test_static_cache.py
@@ -1,0 +1,40 @@
+"""Regression tests for static-asset cache-busting.
+
+A stale cached ``unified_tree.js`` (served with only ETag/Last-Modified and no
+Cache-Control) once left the Entity Graph tab present but non-functional for
+returning visitors. The fix: version asset URLs with ``?v=<mtime>`` and send an
+explicit ``Cache-Control`` so browsers revalidate. These tests lock that in.
+"""
+
+import re
+
+
+def test_tree_assets_are_version_stamped(client):
+    """App JS/CSS in the tree page carry a ``?v=<digits>`` cache-busting token."""
+    html = client.get("/explore/tree").text
+    for asset in (
+        "css/styles.css",
+        "js/copy_iri.js",
+        "js/split_pane.js",
+        "js/unified_tree.js",
+        "js/entity_graph.js",
+    ):
+        assert re.search(
+            rf"/static/{re.escape(asset)}\?v=\d+", html
+        ), f"{asset} is not version-stamped in /explore/tree"
+
+
+def test_static_assets_send_cache_control(client):
+    """Static responses carry a revalidating Cache-Control header."""
+    response = client.get("/static/js/entity_graph.js")
+    assert response.status_code == 200
+    cache_control = response.headers.get("cache-control", "")
+    assert "must-revalidate" in cache_control, (
+        f"expected a revalidating Cache-Control, got: {cache_control!r}"
+    )
+
+
+def test_version_stamped_url_still_serves(client):
+    """The ``?v=`` query does not break static file resolution."""
+    response = client.get("/static/js/unified_tree.js?v=1234567890")
+    assert response.status_code == 200


### PR DESCRIPTION
## Problem

The Entity Graph tab rendered blank for some visitors on production. Root cause was **not** the graph code — it was **stale browser cache**:

- Static JS/CSS were served with only `ETag`/`Last-Modified` and **no `Cache-Control`**, and asset URLs had **no cache-busting**.
- Browsers therefore applied *heuristic* freshness and kept serving a **stale `unified_tree.js`** (which existed pre-Entity-Graph) long after the deploy.
- Result: new HTML (Entity Graph tab present) + old cached `unified_tree.js` (no graph wiring) = a dead tab.

## Fix

- **Version-stamp** app asset URLs with `?v={{ asset_version }}` (token = newest static-file mtime), so every deploy changes the URL and busts the cache.
- **`CachedStaticFiles`** sets `Cache-Control: public, max-age=3600, must-revalidate` so browsers revalidate instead of guessing.
- **Regression tests** for both stamping and cache headers.

## Also folded in (prod deploy hygiene)

So future prod deploys need no manual drift re-application:

- `docker-compose.yml`: pass `XAI_API_KEY` through to the container.
- `docker/Caddyfile`: add the `soli.openlegalstandard.org` block; **drop `rate_limit`** — it needs a Caddy plugin absent from stock `caddy:latest`, which broke `docker compose up` for anyone using the repo as-is. (`config.json`'s LLM choice stays host-local by design.)

## Verification

- `uv run pytest` → 16 passed (3 new).
- Verified locally: `/explore/tree` emits `?v=` on all app assets; `/static/*` returns `Cache-Control: …must-revalidate`; versioned URLs serve 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)