### PR TITLE
feat(security): restore rate limiting at the app level (portable across proxies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,9 +168,14 @@ headers; allowed responses carry `X-RateLimit-Remaining`.
 | Key | Description | Default |
 |---|---|---|
 | `enabled` | Toggle limiting on/off | `true` |
-| `storage_uri` | `memory://` (per-process) or `redis://host:6379` for multi-worker/replica | `memory://` |
-| `trusted_proxy_hops` | Reverse-proxy hops to trust for `X-Forwarded-For` (the rightmost N entries); set `0` if exposed with no proxy | `1` |
+| `storage_uri` | `memory://` (per-process) or `redis://host:6379` for multi-worker/replica (requires the `limits[async-redis]` extra) | `memory://` |
+| `trusted_proxy_hops` | Reverse-proxy hops to trust for `X-Forwarded-For` (the rightmost N entries); set `0` to always key on the socket IP | `1` |
 | `tiers` | Map of path prefix → limit string or list; `default` is the fallback | see table above |
+
+`X-Forwarded-For` is only honored when the socket peer is a private/loopback
+address (i.e. plausibly our own Caddy/Traefik) — a direct internet client can
+never spoof the header to rotate rate-limit buckets, even if the app port is
+accidentally exposed without a proxy.
 
 ### LLM Configuration
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,31 @@ The API can be configured using the `config.json` file. The main configuration s
 
 - `folio`: Settings for the FOLIO ontology source (GitHub repository or HTTP URL)
 - `llm`: Configuration for the LLM model used for semantic searches
-- `api`: API metadata, binding options, and CORS settings
+- `api`: API metadata, binding options, CORS settings, and `rate_limit`
+
+### Rate Limiting
+
+The API rate-limits by client IP at the application layer (`api.rate_limit` in
+`config.json`), so the protection is portable across every deploy target
+(Caddy on bare-metal, Traefik/Coolify on dev, Railway) instead of living in one
+proxy's config. Tiers are matched by path prefix (longest match wins):
+
+| Tier | Default limit | Applies to |
+|---|---|---|
+| `/search/llm/` | `10/minute`, `100/hour` | Paid LLM semantic-search routes (real OpenAI/XAI cost) — tightest |
+| `/search/` | `60/minute`, `1000/hour` | Non-LLM search routes — moderate |
+| `default` | `240/minute` | Everything else — generous |
+
+Health (`/info/health`), static assets, docs, and `/mcp` are exempt. Exceeding
+a limit returns **HTTP 429** with a `Retry-After` header and `X-RateLimit-*`
+headers; allowed responses carry `X-RateLimit-Remaining`.
+
+| Key | Description | Default |
+|---|---|---|
+| `enabled` | Toggle limiting on/off | `true` |
+| `storage_uri` | `memory://` (per-process) or `redis://host:6379` for multi-worker/replica | `memory://` |
+| `trusted_proxy_hops` | Reverse-proxy hops to trust for `X-Forwarded-For` (the rightmost N entries); set `0` if exposed with no proxy | `1` |
+| `tiers` | Map of path prefix → limit string or list; `default` is the fallback | see table above |
 
 ### LLM Configuration
 
@@ -232,9 +256,10 @@ Caddy provides:
 
 - **Automatic HTTPS**: TLS certificates are automatically managed in production
 - **Security headers**: HSTS, XSS protection, and other security headers
-- **Rate limiting**: Prevents abuse of the API
 - **Gzip compression**: Reduces bandwidth usage
 - **Structured logging**: JSON logs for better monitoring
+
+Rate limiting is enforced at the application layer (see [Rate Limiting](#rate-limiting)) rather than in Caddy, so it travels with the app across all deploy targets.
 
 ## Contributing
 

--- a/THIRD-PARTY.md
+++ b/THIRD-PARTY.md
@@ -18,4 +18,14 @@ Information Ontology), maintained by the **ALEA Institute**, originating from th
 | Component | License |
 |-----------|---------|
 | folio-python[search], fastapi, folio-mcp | MIT |
+| `limits` (>=3.13,<6; pinned to 5.8.0 in `uv.lock`) | MIT |
 | uvicorn, jinja2 | BSD-3-Clause |
+
+`limits` (https://github.com/alisaifee/limits, MIT) is the rate-limiting
+primitive behind `folio_api/rate_limit.py` — the same engine `slowapi` /
+`flask-limiter` wrap. We depend on it directly and drive it from one
+pure-ASGI middleware (centralized per-path tiers; no per-route decorators;
+SSE-safe for the mounted `/mcp` app), rather than pulling in `slowapi`'s
+decorator layer. Added 2026-07-07 to restore rate limiting at the app level
+(portable across Caddy/Traefik/Coolify) after the edge Caddy directive was
+dropped in PR #19.

--- a/config.json
+++ b/config.json
@@ -26,6 +26,16 @@
     "cors_origins": [
       "*"
     ],
-    "log_level": "info"
+    "log_level": "info",
+    "rate_limit": {
+      "enabled": true,
+      "storage_uri": "memory://",
+      "trusted_proxy_hops": 1,
+      "tiers": {
+        "/search/llm/": ["10/minute", "100/hour"],
+        "/search/": ["60/minute", "1000/hour"],
+        "default": ["240/minute"]
+      }
+    }
   }
 }

--- a/config.json.example
+++ b/config.json.example
@@ -27,6 +27,17 @@
     "bind_ip": "0.0.0.0",
     "bind_port": 8000,
     "cors_origins": ["*"],
-    "log_level": "info"
+    "log_level": "info",
+    "_rate_limit_note": "App-level IP rate limiting. Tightest tier on paid /search/llm/* routes. trusted_proxy_hops=1 trusts one reverse proxy (Caddy/Traefik) for X-Forwarded-For; set 0 if exposed with no proxy. For multi-worker/replica deploys set storage_uri to redis://host:6379 (memory:// is per-process).",
+    "rate_limit": {
+      "enabled": true,
+      "storage_uri": "memory://",
+      "trusted_proxy_hops": 1,
+      "tiers": {
+        "/search/llm/": ["10/minute", "100/hour"],
+        "/search/": ["60/minute", "1000/hour"],
+        "default": ["240/minute"]
+      }
+    }
   }
 }

--- a/config.json.example
+++ b/config.json.example
@@ -28,7 +28,7 @@
     "bind_port": 8000,
     "cors_origins": ["*"],
     "log_level": "info",
-    "_rate_limit_note": "App-level IP rate limiting. Tightest tier on paid /search/llm/* routes. trusted_proxy_hops=1 trusts one reverse proxy (Caddy/Traefik) for X-Forwarded-For; set 0 if exposed with no proxy. For multi-worker/replica deploys set storage_uri to redis://host:6379 (memory:// is per-process).",
+    "_rate_limit_note": "App-level IP rate limiting. Tightest tier on paid /search/llm/* routes. X-Forwarded-For is only trusted when the socket peer is a private/loopback proxy address AND trusted_proxy_hops>0 (rightmost N entries); set 0 to always key on the socket IP. For multi-worker/replica deploys set storage_uri to redis://host:6379 (memory:// is per-process; redis requires the limits[async-redis] extra).",
     "rate_limit": {
       "enabled": true,
       "storage_uri": "memory://",

--- a/folio_api/api.py
+++ b/folio_api/api.py
@@ -34,6 +34,7 @@ import folio_api.routes.properties
 import folio_api.routes.explore
 import folio_api.routes.connections
 from folio_api.api_config import load_config
+from folio_api.rate_limit import RateLimitConfig, RateLimitMiddleware
 
 _DEFAULT_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
@@ -189,7 +190,11 @@ def initialize_folio(folio_config: Dict[str, Any], llm_config: Dict[str, Any]) -
     )
     # Treat un-substituted "${ENV_VAR}" placeholders as missing so the literal
     # string isn't passed to the LLM client as a key. Falls back to env var.
-    if isinstance(llm_api_key, str) and llm_api_key.startswith("${") and llm_api_key.endswith("}"):
+    if (
+        isinstance(llm_api_key, str)
+        and llm_api_key.startswith("${")
+        and llm_api_key.endswith("}")
+    ):
         llm_api_key = os.getenv(_API_KEY_ENV_VARS.get(llm_engine, "OPENAI_API_KEY"))
     llm_effort = llm_config.get("effort", None)
     llm_tier = llm_config.get("tier", None)
@@ -276,6 +281,18 @@ def get_app() -> FastAPI:
         },
         lifespan=lifespan_handler,
     )
+
+    # App-level rate limiting (portable across Caddy/Traefik/Coolify/Railway).
+    # Added before CORS so that CORS ends up the OUTERMOST middleware and its
+    # headers are applied even to a 429 — browsers can then read the rejection.
+    # Tiers/limits come from config.json ``api.rate_limit`` (module defaults if
+    # absent). See folio_api/rate_limit.py for the design rationale.
+    rate_limit_config = RateLimitConfig(api_config.get("rate_limit"))
+    if rate_limit_config.enabled:
+        app_instance.add_middleware(
+            RateLimitMiddleware,  # type: ignore
+            config=rate_limit_config,
+        )
 
     # Enable CORS as this is a public API by default.
     app_instance.add_middleware(

--- a/folio_api/rate_limit.py
+++ b/folio_api/rate_limit.py
@@ -10,51 +10,58 @@ the limiter travels with the code instead of living in one proxy's config.
 
 Design:
   * **Engine:** the ``limits`` library (the same primitive ``slowapi`` /
-    ``flask-limiter`` wrap). We drive it directly from a single pure-ASGI
-    middleware rather than decorating ~20 ``/search/llm/*`` routes one-by-one:
-    tiers stay centralized in one config dict, and pure-ASGI passes streaming
-    responses (the mounted ``/mcp`` SSE app) through untouched — a
-    ``BaseHTTPMiddleware`` would buffer and break them.
+    ``flask-limiter`` wrap), via its **async** strategy so a networked storage
+    backend (``redis://``) never blocks the event loop. We drive it directly
+    from a single pure-ASGI middleware rather than decorating ~20
+    ``/search/llm/*`` routes one-by-one: tiers stay centralized in one config
+    dict, and pure-ASGI passes streaming responses (the mounted ``/mcp`` SSE
+    app) through untouched — a ``BaseHTTPMiddleware`` would buffer and break
+    them.
   * **Tiers by path prefix:** tightest on the paid ``/search/llm/*`` routes,
     moderate on the other ``/search/*`` routes, generous default everywhere
-    else. Health, static, docs and ``/mcp`` are exempt.
-  * **Key = client IP, proxy-aware.** Behind a single trusted reverse proxy
-    (Caddy/Traefik) the real client is the *rightmost* entry of
-    ``X-Forwarded-For`` (the proxy appends the socket peer it actually saw, so
-    a client-spoofed leftmost value is ignored). ``trusted_proxy_hops`` makes
-    the number of trusted hops configurable; set it to ``0`` if the app is ever
-    exposed to the internet with no proxy in front (then only the socket IP is
-    trusted).
+    else. Health, static, docs and ``/mcp`` are exempt (segment-boundary
+    matched, so ``/mcp-evil`` is NOT exempt).
+  * **Key = client IP, proxy-aware AND socket-gated.** ``X-Forwarded-For`` is
+    only consulted when the *socket peer* is a plausible reverse proxy
+    (loopback / RFC-1918 / CGNAT / link-local / ULA — i.e. the docker network
+    Caddy/Traefik connect from). A direct internet client therefore can never
+    spoof XFF to rotate buckets: its own socket IP is used. Behind the trusted
+    proxy, the real client is the *rightmost* XFF entry (the proxy appends the
+    peer it actually saw), with ``trusted_proxy_hops`` configurable for deeper
+    chains; ``0`` disables XFF trust entirely.
   * **429 + Retry-After** plus ``X-RateLimit-*`` headers on limited responses.
 
 Scaling note: the default ``memory://`` storage is per-process. uvicorn runs a
 single worker here, so counts are global. If this ever runs multiple
 workers/replicas, point ``rate_limit.storage_uri`` at Redis
 (``redis://host:6379``) so the window is shared — otherwise the effective limit
-multiplies by the worker count.
+multiplies by the worker count. The redis path additionally requires the
+``limits[async-redis]`` extra to be installed.
 """
 
 from __future__ import annotations
 
+import ipaddress
 import time
-from typing import Any, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Sequence
 
 from limits import RateLimitItem, parse
+from limits.aio.storage import Storage as AsyncStorage
+from limits.aio.strategies import MovingWindowRateLimiter
 from limits.storage import storage_from_string
-from limits.strategies import MovingWindowRateLimiter
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 # Sensible built-in defaults, used when config.json has no ``api.rate_limit``
 # block so an old config still gets protected. Ordered most→least specific;
 # longest matching prefix wins.
-DEFAULT_TIERS: Dict[str, List[str]] = {
+DEFAULT_TIERS: dict[str, list[str]] = {
     "/search/llm/": ["10/minute", "100/hour"],  # paid LLM calls — tightest
     "/search/": ["60/minute", "1000/hour"],  # non-LLM search — moderate
     "default": ["240/minute"],  # everything else — generous
 }
 
-DEFAULT_EXEMPT_PREFIXES: List[str] = [
+DEFAULT_EXEMPT_PREFIXES: list[str] = [
     "/info/health",  # Docker/Coolify/uptime probes — never limit liveness
     "/static",
     "/openapi.json",
@@ -64,6 +71,42 @@ DEFAULT_EXEMPT_PREFIXES: List[str] = [
     "/favicon.ico",
 ]
 
+# Socket-peer networks from which we accept X-Forwarded-For as proxy-written.
+# These cover every topology we deploy: docker bridge/compose networks
+# (RFC 1918), Coolify/Traefik overlay nets, CGNAT (100.64/10), loopback for
+# on-box proxies, and their IPv6 equivalents. A *public* socket peer is by
+# definition not our reverse proxy, so its XFF header is attacker-controlled
+# and must be ignored — this is what makes bucket-rotation-by-spoofed-XFF
+# impossible even if the app port is accidentally exposed to the internet.
+_PROXY_NETWORKS: tuple[ipaddress.IPv4Network | ipaddress.IPv6Network, ...] = (
+    ipaddress.ip_network("127.0.0.0/8"),
+    ipaddress.ip_network("10.0.0.0/8"),
+    ipaddress.ip_network("172.16.0.0/12"),
+    ipaddress.ip_network("192.168.0.0/16"),
+    ipaddress.ip_network("100.64.0.0/10"),
+    ipaddress.ip_network("169.254.0.0/16"),
+    ipaddress.ip_network("::1/128"),
+    ipaddress.ip_network("fc00::/7"),
+    ipaddress.ip_network("fe80::/10"),
+)
+
+
+def _is_proxy_peer(host: str | None) -> bool:
+    """True if the socket peer could be our reverse proxy.
+
+    Non-IP hosts (e.g. Starlette's ``TestClient`` uses the literal string
+    ``"testclient"``; UDS transports have no peer) can only occur in embedded
+    or test transports — never on a real TCP connection, where uvicorn always
+    reports an IP — so they are treated as trusted.
+    """
+    if host is None:
+        return True
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        return True  # embedded/test transport, not a real TCP peer
+    return any(addr in net for net in _PROXY_NETWORKS)
+
 
 class RateLimitConfig:
     """Parsed, validated rate-limit configuration.
@@ -72,39 +115,48 @@ class RateLimitConfig:
     optional; missing keys fall back to the module defaults).
     """
 
-    def __init__(self, raw: Optional[Dict[str, Any]] = None) -> None:
+    def __init__(self, raw: dict[str, Any] | None = None) -> None:
         raw = raw or {}
         self.enabled: bool = bool(raw.get("enabled", True))
         self.storage_uri: str = raw.get("storage_uri", "memory://")
         self.trusted_proxy_hops: int = int(raw.get("trusted_proxy_hops", 1))
-        self.exempt_prefixes: List[str] = list(
+        self.exempt_prefixes: list[str] = list(
             raw.get("exempt_prefixes", DEFAULT_EXEMPT_PREFIXES)
         )
 
-        tiers_raw: Dict[str, Any] = dict(raw.get("tiers", DEFAULT_TIERS))
+        tiers_raw: dict[str, Any] = dict(raw.get("tiers", DEFAULT_TIERS))
         if "default" not in tiers_raw:
             tiers_raw["default"] = DEFAULT_TIERS["default"]
 
         # name/prefix -> parsed RateLimitItem list. "default" is the fallback.
-        self.tiers: Dict[str, List[RateLimitItem]] = {}
+        self.tiers: dict[str, list[RateLimitItem]] = {}
         for name, limits_spec in tiers_raw.items():
             if isinstance(limits_spec, str):
                 limits_spec = [limits_spec]
+            if not limits_spec:
+                raise ValueError(
+                    f"rate_limit tier {name!r} has no limits; remove the tier "
+                    "or give it at least one limit string (e.g. '60/minute')"
+                )
             self.tiers[name] = [parse(spec) for spec in limits_spec]
 
         # Prefixes (everything but "default"), longest first so the most
         # specific tier wins (e.g. "/search/llm/" before "/search/").
-        self._prefixes: List[str] = sorted(
+        self._prefixes: list[str] = sorted(
             (p for p in self.tiers if p != "default"),
             key=len,
             reverse=True,
         )
 
     def is_exempt(self, path: str) -> bool:
-        """True if ``path`` is under an exempt prefix (no limiting applied)."""
-        return any(path.startswith(pref) for pref in self.exempt_prefixes)
+        """True if ``path`` is under an exempt prefix (no limiting applied).
 
-    def limits_for(self, path: str) -> Tuple[str, List[RateLimitItem]]:
+        Segment-boundary matched: ``/mcp`` exempts ``/mcp`` and ``/mcp/...``
+        but NOT ``/mcp-evil`` — a bare ``startswith`` would over-exempt.
+        """
+        return any(_prefix_match(path, pref) for pref in self.exempt_prefixes)
+
+    def limits_for(self, path: str) -> tuple[str, list[RateLimitItem]]:
         """Return ``(tier_name, limits)`` for a request path."""
         for pref in self._prefixes:
             if path.startswith(pref):
@@ -112,35 +164,70 @@ class RateLimitConfig:
         return "default", self.tiers["default"]
 
 
+def _prefix_match(path: str, prefix: str) -> bool:
+    """Prefix match that respects path-segment boundaries."""
+    if prefix.endswith("/"):
+        return path.startswith(prefix) or path == prefix.rstrip("/")
+    return path == prefix or path.startswith(prefix + "/")
+
+
 def client_ip_from_scope(scope: Scope, trusted_proxy_hops: int) -> str:
     """Resolve the real client IP from an ASGI scope, proxy-aware.
 
+    ``X-Forwarded-For`` is honored only when BOTH hold:
+      1. ``trusted_proxy_hops > 0``, and
+      2. the socket peer is a plausible proxy address (loopback/private —
+         see ``_PROXY_NETWORKS``). A public socket peer connected directly,
+         so its XFF header is client-controlled noise and is ignored.
+
     With ``trusted_proxy_hops == N`` and a chain
     ``client -> proxy1 -> ... -> proxyN -> app``, the real client is the entry
-    ``N`` positions from the right of ``X-Forwarded-For`` (each trusted proxy
-    appends the peer it saw; the rightmost ``N`` entries are the ones our own
-    trusted proxies wrote, so a client-supplied leftmost value can't spoof the
-    key). Falls back to the socket peer when there is no usable header.
+    ``N`` positions from the right of the (comma-joined) XFF value: each
+    trusted proxy appends the peer it saw, so the rightmost ``N`` entries were
+    written by our own proxies and a client-supplied leftmost value can't
+    spoof the key. Falls back to the socket peer when there is no usable
+    header.
     """
-    if trusted_proxy_hops > 0:
-        xff = _header(scope, b"x-forwarded-for")
+    client = scope.get("client")
+    socket_host: str | None = client[0] if client else None
+
+    if trusted_proxy_hops > 0 and _is_proxy_peer(socket_host):
+        xff = _xff_joined(scope)
         if xff:
             parts = [p.strip() for p in xff.split(",") if p.strip()]
             if parts:
                 idx = min(trusted_proxy_hops, len(parts))
                 return parts[-idx]
 
-    client = scope.get("client")
-    if client:
-        return client[0]
-    return "unknown"
+    return socket_host if socket_host is not None else "unknown"
 
 
-def _header(scope: Scope, name: bytes) -> Optional[str]:
-    for key, value in scope.get("headers", []):
-        if key == name:
-            return value.decode("latin-1")
-    return None
+def _xff_joined(scope: Scope) -> str | None:
+    """All ``X-Forwarded-For`` header values, comma-joined in wire order.
+
+    A client may smuggle its own XFF as a *separate* header line before the
+    proxy-appended one; taking only the first line would return the forged
+    value. Joining preserves order, keeping the proxy-written entry rightmost.
+    """
+    values = [
+        value.decode("latin-1")
+        for key, value in scope.get("headers", [])
+        if key == b"x-forwarded-for"
+    ]
+    return ",".join(values) if values else None
+
+
+def _async_storage(storage_uri: str) -> AsyncStorage:
+    """Build the async variant of the configured storage backend.
+
+    Config uses the familiar sync-style URIs (``memory://``, ``redis://...``);
+    the ``async+`` scheme prefix selects the asyncio implementations that the
+    async strategy requires.
+    """
+    uri = storage_uri
+    if not uri.startswith("async+"):
+        uri = f"async+{uri}"
+    return storage_from_string(uri)  # type: ignore[return-value]
 
 
 class RateLimitMiddleware:
@@ -149,7 +236,7 @@ class RateLimitMiddleware:
     def __init__(self, app: ASGIApp, config: RateLimitConfig) -> None:
         self.app = app
         self.config = config
-        self.storage = storage_from_string(config.storage_uri)
+        self.storage = _async_storage(config.storage_uri)
         self.limiter = MovingWindowRateLimiter(self.storage)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
@@ -165,9 +252,8 @@ class RateLimitMiddleware:
         tier_name, limits = self.config.limits_for(path)
         key = client_ip_from_scope(scope, self.config.trusted_proxy_hops)
 
-        allowed, offending = self._check(limits, tier_name, key)
-        if not allowed:
-            assert offending is not None
+        offending = await self._check(limits, tier_name, key)
+        if offending is not None:
             await self._reject(
                 offending,
                 tier_name,
@@ -178,11 +264,11 @@ class RateLimitMiddleware:
             )
             return
 
-        # Allowed: surface the tightest remaining budget in response headers.
-        remaining, reset = self._tightest_stats(limits, tier_name, key)
-        limit_header = str(limits[0]) if limits else ""
+        # Allowed: surface the tightest remaining budget in response headers
+        # (limit + remaining + reset all reported from the SAME limit item).
+        tightest, remaining, reset = await self._tightest_stats(limits, tier_name, key)
         rl_headers = [
-            (b"x-ratelimit-limit", limit_header.encode("latin-1")),
+            (b"x-ratelimit-limit", str(tightest).encode("latin-1")),
             (b"x-ratelimit-remaining", str(remaining).encode("latin-1")),
             (b"x-ratelimit-reset", str(int(reset)).encode("latin-1")),
         ]
@@ -196,30 +282,35 @@ class RateLimitMiddleware:
 
         await self.app(scope, receive, send_with_headers)
 
-    def _check(
+    async def _check(
         self, limits: Sequence[RateLimitItem], tier: str, key: str
-    ) -> Tuple[bool, Optional[RateLimitItem]]:
+    ) -> RateLimitItem | None:
         """Consume one hit against every limit in the tier.
 
-        Returns ``(True, None)`` if all pass, else ``(False, offending_limit)``.
+        Returns ``None`` if all pass, else the first offending limit. Note:
+        limits checked *before* the offending one have already been consumed —
+        a slight over-count on rejected requests, acceptable (and fail-safe)
+        for a protective limiter.
         """
         for item in limits:
-            if not self.limiter.hit(item, tier, key):
-                return False, item
-        return True, None
+            if not await self.limiter.hit(item, tier, key):
+                return item
+        return None
 
-    def _tightest_stats(
+    async def _tightest_stats(
         self, limits: Sequence[RateLimitItem], tier: str, key: str
-    ) -> Tuple[int, float]:
-        """Lowest remaining budget (and its reset) across the tier's limits."""
-        remaining = None
+    ) -> tuple[RateLimitItem, int, float]:
+        """The limit with the lowest remaining budget, plus its stats."""
+        tightest = limits[0]
+        remaining: int | None = None
         reset = time.time()
         for item in limits:
-            stats = self.limiter.get_window_stats(item, tier, key)
+            stats = await self.limiter.get_window_stats(item, tier, key)
             if remaining is None or stats.remaining < remaining:
+                tightest = item
                 remaining = stats.remaining
                 reset = stats.reset_time
-        return (remaining if remaining is not None else 0, reset)
+        return tightest, (remaining if remaining is not None else 0), reset
 
     async def _reject(
         self,
@@ -231,14 +322,14 @@ class RateLimitMiddleware:
         receive: Receive,
         send: Send,
     ) -> None:
-        stats = self.limiter.get_window_stats(offending, tier, key)
+        stats = await self.limiter.get_window_stats(offending, tier, key)
         retry_after = max(1, int(round(stats.reset_time - time.time())))
         limit_str = str(offending)
         response = JSONResponse(
             status_code=429,
             content={
                 "detail": (
-                    f"Rate limit exceeded: {limit_str}. " f"Retry in {retry_after}s."
+                    f"Rate limit exceeded: {limit_str}. Retry in {retry_after}s."
                 ),
                 "limit": limit_str,
                 "retry_after": retry_after,

--- a/folio_api/rate_limit.py
+++ b/folio_api/rate_limit.py
@@ -1,0 +1,253 @@
+"""App-level rate limiting for the FOLIO API.
+
+Why app-level (not Caddy/Traefik): the edge rate_limit directive that used to
+guard prod required a Caddy plugin absent from stock ``caddy:latest`` and was
+silently dropped in PR #19 — leaving ``/search/llm/*`` (real, *paid* OpenAI/XAI
+calls) with **zero** limiting: an unauthenticated cost-DoS vector. Enforcing in
+the app makes the protection portable across every deploy target we run (Caddy
+on bare-metal prod, Traefik/Coolify on dev, Railway, plain ``docker run``) —
+the limiter travels with the code instead of living in one proxy's config.
+
+Design:
+  * **Engine:** the ``limits`` library (the same primitive ``slowapi`` /
+    ``flask-limiter`` wrap). We drive it directly from a single pure-ASGI
+    middleware rather than decorating ~20 ``/search/llm/*`` routes one-by-one:
+    tiers stay centralized in one config dict, and pure-ASGI passes streaming
+    responses (the mounted ``/mcp`` SSE app) through untouched — a
+    ``BaseHTTPMiddleware`` would buffer and break them.
+  * **Tiers by path prefix:** tightest on the paid ``/search/llm/*`` routes,
+    moderate on the other ``/search/*`` routes, generous default everywhere
+    else. Health, static, docs and ``/mcp`` are exempt.
+  * **Key = client IP, proxy-aware.** Behind a single trusted reverse proxy
+    (Caddy/Traefik) the real client is the *rightmost* entry of
+    ``X-Forwarded-For`` (the proxy appends the socket peer it actually saw, so
+    a client-spoofed leftmost value is ignored). ``trusted_proxy_hops`` makes
+    the number of trusted hops configurable; set it to ``0`` if the app is ever
+    exposed to the internet with no proxy in front (then only the socket IP is
+    trusted).
+  * **429 + Retry-After** plus ``X-RateLimit-*`` headers on limited responses.
+
+Scaling note: the default ``memory://`` storage is per-process. uvicorn runs a
+single worker here, so counts are global. If this ever runs multiple
+workers/replicas, point ``rate_limit.storage_uri`` at Redis
+(``redis://host:6379``) so the window is shared — otherwise the effective limit
+multiplies by the worker count.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from limits import RateLimitItem, parse
+from limits.storage import storage_from_string
+from limits.strategies import MovingWindowRateLimiter
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+# Sensible built-in defaults, used when config.json has no ``api.rate_limit``
+# block so an old config still gets protected. Ordered most→least specific;
+# longest matching prefix wins.
+DEFAULT_TIERS: Dict[str, List[str]] = {
+    "/search/llm/": ["10/minute", "100/hour"],  # paid LLM calls — tightest
+    "/search/": ["60/minute", "1000/hour"],  # non-LLM search — moderate
+    "default": ["240/minute"],  # everything else — generous
+}
+
+DEFAULT_EXEMPT_PREFIXES: List[str] = [
+    "/info/health",  # Docker/Coolify/uptime probes — never limit liveness
+    "/static",
+    "/openapi.json",
+    "/docs",
+    "/redoc",
+    "/mcp",  # mounted MCP sub-app (SSE) — must pass through untouched
+    "/favicon.ico",
+]
+
+
+class RateLimitConfig:
+    """Parsed, validated rate-limit configuration.
+
+    Built from the ``api.rate_limit`` block of ``config.json`` (all keys
+    optional; missing keys fall back to the module defaults).
+    """
+
+    def __init__(self, raw: Optional[Dict[str, Any]] = None) -> None:
+        raw = raw or {}
+        self.enabled: bool = bool(raw.get("enabled", True))
+        self.storage_uri: str = raw.get("storage_uri", "memory://")
+        self.trusted_proxy_hops: int = int(raw.get("trusted_proxy_hops", 1))
+        self.exempt_prefixes: List[str] = list(
+            raw.get("exempt_prefixes", DEFAULT_EXEMPT_PREFIXES)
+        )
+
+        tiers_raw: Dict[str, Any] = dict(raw.get("tiers", DEFAULT_TIERS))
+        if "default" not in tiers_raw:
+            tiers_raw["default"] = DEFAULT_TIERS["default"]
+
+        # name/prefix -> parsed RateLimitItem list. "default" is the fallback.
+        self.tiers: Dict[str, List[RateLimitItem]] = {}
+        for name, limits_spec in tiers_raw.items():
+            if isinstance(limits_spec, str):
+                limits_spec = [limits_spec]
+            self.tiers[name] = [parse(spec) for spec in limits_spec]
+
+        # Prefixes (everything but "default"), longest first so the most
+        # specific tier wins (e.g. "/search/llm/" before "/search/").
+        self._prefixes: List[str] = sorted(
+            (p for p in self.tiers if p != "default"),
+            key=len,
+            reverse=True,
+        )
+
+    def is_exempt(self, path: str) -> bool:
+        """True if ``path`` is under an exempt prefix (no limiting applied)."""
+        return any(path.startswith(pref) for pref in self.exempt_prefixes)
+
+    def limits_for(self, path: str) -> Tuple[str, List[RateLimitItem]]:
+        """Return ``(tier_name, limits)`` for a request path."""
+        for pref in self._prefixes:
+            if path.startswith(pref):
+                return pref, self.tiers[pref]
+        return "default", self.tiers["default"]
+
+
+def client_ip_from_scope(scope: Scope, trusted_proxy_hops: int) -> str:
+    """Resolve the real client IP from an ASGI scope, proxy-aware.
+
+    With ``trusted_proxy_hops == N`` and a chain
+    ``client -> proxy1 -> ... -> proxyN -> app``, the real client is the entry
+    ``N`` positions from the right of ``X-Forwarded-For`` (each trusted proxy
+    appends the peer it saw; the rightmost ``N`` entries are the ones our own
+    trusted proxies wrote, so a client-supplied leftmost value can't spoof the
+    key). Falls back to the socket peer when there is no usable header.
+    """
+    if trusted_proxy_hops > 0:
+        xff = _header(scope, b"x-forwarded-for")
+        if xff:
+            parts = [p.strip() for p in xff.split(",") if p.strip()]
+            if parts:
+                idx = min(trusted_proxy_hops, len(parts))
+                return parts[-idx]
+
+    client = scope.get("client")
+    if client:
+        return client[0]
+    return "unknown"
+
+
+def _header(scope: Scope, name: bytes) -> Optional[str]:
+    for key, value in scope.get("headers", []):
+        if key == name:
+            return value.decode("latin-1")
+    return None
+
+
+class RateLimitMiddleware:
+    """Pure-ASGI middleware enforcing per-path-tier IP rate limits."""
+
+    def __init__(self, app: ASGIApp, config: RateLimitConfig) -> None:
+        self.app = app
+        self.config = config
+        self.storage = storage_from_string(config.storage_uri)
+        self.limiter = MovingWindowRateLimiter(self.storage)
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path: str = scope.get("path", "")
+        if self.config.is_exempt(path):
+            await self.app(scope, receive, send)
+            return
+
+        tier_name, limits = self.config.limits_for(path)
+        key = client_ip_from_scope(scope, self.config.trusted_proxy_hops)
+
+        allowed, offending = self._check(limits, tier_name, key)
+        if not allowed:
+            assert offending is not None
+            await self._reject(
+                offending,
+                tier_name,
+                key,
+                scope=scope,
+                receive=receive,
+                send=send,
+            )
+            return
+
+        # Allowed: surface the tightest remaining budget in response headers.
+        remaining, reset = self._tightest_stats(limits, tier_name, key)
+        limit_header = str(limits[0]) if limits else ""
+        rl_headers = [
+            (b"x-ratelimit-limit", limit_header.encode("latin-1")),
+            (b"x-ratelimit-remaining", str(remaining).encode("latin-1")),
+            (b"x-ratelimit-reset", str(int(reset)).encode("latin-1")),
+        ]
+
+        async def send_with_headers(message: Message) -> None:
+            if message["type"] == "http.response.start":
+                headers = list(message.get("headers", []))
+                headers.extend(rl_headers)
+                message = {**message, "headers": headers}
+            await send(message)
+
+        await self.app(scope, receive, send_with_headers)
+
+    def _check(
+        self, limits: Sequence[RateLimitItem], tier: str, key: str
+    ) -> Tuple[bool, Optional[RateLimitItem]]:
+        """Consume one hit against every limit in the tier.
+
+        Returns ``(True, None)`` if all pass, else ``(False, offending_limit)``.
+        """
+        for item in limits:
+            if not self.limiter.hit(item, tier, key):
+                return False, item
+        return True, None
+
+    def _tightest_stats(
+        self, limits: Sequence[RateLimitItem], tier: str, key: str
+    ) -> Tuple[int, float]:
+        """Lowest remaining budget (and its reset) across the tier's limits."""
+        remaining = None
+        reset = time.time()
+        for item in limits:
+            stats = self.limiter.get_window_stats(item, tier, key)
+            if remaining is None or stats.remaining < remaining:
+                remaining = stats.remaining
+                reset = stats.reset_time
+        return (remaining if remaining is not None else 0, reset)
+
+    async def _reject(
+        self,
+        offending: RateLimitItem,
+        tier: str,
+        key: str,
+        *,
+        scope: Scope,
+        receive: Receive,
+        send: Send,
+    ) -> None:
+        stats = self.limiter.get_window_stats(offending, tier, key)
+        retry_after = max(1, int(round(stats.reset_time - time.time())))
+        limit_str = str(offending)
+        response = JSONResponse(
+            status_code=429,
+            content={
+                "detail": (
+                    f"Rate limit exceeded: {limit_str}. " f"Retry in {retry_after}s."
+                ),
+                "limit": limit_str,
+                "retry_after": retry_after,
+            },
+            headers={
+                "Retry-After": str(retry_after),
+                "X-RateLimit-Limit": limit_str,
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Reset": str(int(stats.reset_time)),
+            },
+        )
+        await response(scope, receive, send)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "uvicorn>=0.30.6",
     "jinja2>=3.1.6",
     "folio-mcp>=0.2.0",
+    "limits>=3.13,<6",
 ]
 
 [project.urls]

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,242 @@
+"""Tests for app-level rate limiting (folio_api/rate_limit.py).
+
+Self-contained: each test builds a tiny Starlette app wrapped in
+``RateLimitMiddleware`` with small, fast limits and a fresh in-memory store, so
+nothing depends on the FOLIO ontology load or the real config thresholds. This
+keeps the suite deterministic and instant.
+
+Coverage:
+  * per-route tiers — the paid ``/search/llm/*`` tier is tighter than the
+    moderate ``/search/*`` tier, which is tighter than the generous default;
+  * 429 body + ``Retry-After``/``X-RateLimit-*`` header handling;
+  * ``X-Forwarded-For`` parsing — separate IPs get separate buckets, a
+    client-spoofed leftmost value is ignored (rightmost trusted), and
+    ``trusted_proxy_hops`` controls how many hops are trusted;
+  * exempt prefixes are never limited.
+"""
+
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from fastapi.testclient import TestClient
+
+from folio_api.rate_limit import (
+    RateLimitConfig,
+    RateLimitMiddleware,
+    client_ip_from_scope,
+)
+
+
+def _make_client(raw_config: dict) -> TestClient:
+    """Tiny app with three probe routes covering the three tiers + an exempt
+    health route, wrapped in the middleware under test."""
+
+    async def ok(request):  # noqa: ANN001
+        return PlainTextResponse("ok")
+
+    app = Starlette(
+        routes=[
+            Route("/search/llm/events", ok),
+            Route("/search/prefix", ok),
+            Route("/taxonomy/tree", ok),  # falls through to default tier
+            Route("/info/health", ok),  # exempt
+        ]
+    )
+    app.add_middleware(RateLimitMiddleware, config=RateLimitConfig(raw_config))
+    # raise_server_exceptions so any middleware bug surfaces as a test error.
+    return TestClient(app, raise_server_exceptions=True)
+
+
+# ─────────────────────────── tier enforcement ───────────────────────────
+
+
+def test_llm_tier_is_tightest():
+    """The paid /search/llm/* tier rejects after its (small) threshold."""
+    client = _make_client(
+        {
+            "tiers": {
+                "/search/llm/": ["2/minute"],
+                "/search/": ["5/minute"],
+                "default": ["100/minute"],
+            }
+        }
+    )
+    assert client.get("/search/llm/events?query=x").status_code == 200
+    assert client.get("/search/llm/events?query=x").status_code == 200
+    r = client.get("/search/llm/events?query=x")
+    assert r.status_code == 429
+
+
+def test_search_tier_more_generous_than_llm():
+    """The moderate /search/ tier allows more than the llm tier before 429."""
+    client = _make_client(
+        {
+            "tiers": {
+                "/search/llm/": ["2/minute"],
+                "/search/": ["5/minute"],
+                "default": ["100/minute"],
+            }
+        }
+    )
+    # 5 allowed on the moderate tier, 6th rejected.
+    for _ in range(5):
+        assert client.get("/search/prefix?query=x").status_code == 200
+    assert client.get("/search/prefix?query=x").status_code == 429
+
+
+def test_most_specific_prefix_wins():
+    """/search/llm/ must match its own tier, not the broader /search/ tier."""
+    client = _make_client(
+        {
+            "tiers": {
+                "/search/llm/": ["1/minute"],
+                "/search/": ["50/minute"],
+                "default": ["100/minute"],
+            }
+        }
+    )
+    assert client.get("/search/llm/events?query=x").status_code == 200
+    assert client.get("/search/llm/events?query=x").status_code == 429
+    # the moderate /search/ route is unaffected by the llm bucket
+    assert client.get("/search/prefix?query=x").status_code == 200
+
+
+def test_default_tier_applies_to_other_paths():
+    client = _make_client(
+        {"tiers": {"/search/": ["50/minute"], "default": ["2/minute"]}}
+    )
+    assert client.get("/taxonomy/tree").status_code == 200
+    assert client.get("/taxonomy/tree").status_code == 200
+    assert client.get("/taxonomy/tree").status_code == 429
+
+
+# ──────────────────────────── 429 headers ───────────────────────────────
+
+
+def test_429_has_retry_after_and_ratelimit_headers():
+    client = _make_client(
+        {"tiers": {"/search/llm/": ["1/minute"], "default": ["100/minute"]}}
+    )
+    assert client.get("/search/llm/events?query=x").status_code == 200
+    r = client.get("/search/llm/events?query=x")
+    assert r.status_code == 429
+    assert "Retry-After" in r.headers
+    assert int(r.headers["Retry-After"]) >= 1
+    assert r.headers["X-RateLimit-Remaining"] == "0"
+    assert r.headers["X-RateLimit-Limit"]  # non-empty (e.g. "1 per 1 minute")
+    body = r.json()
+    assert body["retry_after"] >= 1
+    assert "limit" in body
+
+
+def test_allowed_response_carries_ratelimit_headers():
+    client = _make_client(
+        {"tiers": {"/search/": ["5/minute"], "default": ["100/minute"]}}
+    )
+    r = client.get("/search/prefix?query=x")
+    assert r.status_code == 200
+    # 5 allowed, one consumed -> 4 remaining
+    assert r.headers["X-RateLimit-Remaining"] == "4"
+
+
+# ────────────────────────── exempt prefixes ─────────────────────────────
+
+
+def test_health_is_exempt():
+    """Liveness probes must never be limited or carry limiter headers."""
+    client = _make_client({"tiers": {"default": ["1/minute"]}})
+    for _ in range(10):
+        r = client.get("/info/health")
+        assert r.status_code == 200
+    assert "X-RateLimit-Remaining" not in r.headers
+
+
+# ─────────────────── X-Forwarded-For / proxy trust ──────────────────────
+
+
+def test_separate_client_ips_get_separate_buckets():
+    client = _make_client(
+        {"tiers": {"/search/llm/": ["1/minute"], "default": ["100/minute"]}}
+    )
+    h1 = {"X-Forwarded-For": "203.0.113.1"}
+    h2 = {"X-Forwarded-For": "203.0.113.2"}
+    assert client.get("/search/llm/events?query=x", headers=h1).status_code == 200
+    # second request from the SAME ip -> limited
+    assert client.get("/search/llm/events?query=x", headers=h1).status_code == 429
+    # a different client ip still has its own budget
+    assert client.get("/search/llm/events?query=x", headers=h2).status_code == 200
+
+
+def test_spoofed_leftmost_xff_is_ignored():
+    """With one trusted hop the rightmost XFF entry (appended by our proxy) is
+    the key; a client-supplied leftmost value cannot rotate to evade limits."""
+    client = _make_client(
+        {"tiers": {"/search/llm/": ["1/minute"], "default": ["100/minute"]}}
+    )
+    # Same real client (rightmost 198.51.100.9), different spoofed leftmost.
+    r1 = client.get(
+        "/search/llm/events?query=x",
+        headers={"X-Forwarded-For": "1.1.1.1, 198.51.100.9"},
+    )
+    r2 = client.get(
+        "/search/llm/events?query=x",
+        headers={"X-Forwarded-For": "2.2.2.2, 198.51.100.9"},
+    )
+    assert r1.status_code == 200
+    assert r2.status_code == 429  # same real client -> still limited
+
+
+def test_client_ip_from_scope_rightmost_with_one_hop():
+    scope = {
+        "client": ("172.17.0.1", 5000),
+        "headers": [(b"x-forwarded-for", b"1.1.1.1, 198.51.100.9")],
+    }
+    assert client_ip_from_scope(scope, trusted_proxy_hops=1) == "198.51.100.9"
+
+
+def test_client_ip_from_scope_two_hops():
+    scope = {
+        "client": ("172.17.0.1", 5000),
+        "headers": [(b"x-forwarded-for", b"real, proxyA, proxyB")],
+    }
+    # trust 2 hops -> the entry 2 from the right = "proxyA"'s left neighbor
+    assert client_ip_from_scope(scope, trusted_proxy_hops=2) == "proxyA"
+
+
+def test_client_ip_from_scope_zero_hops_uses_socket():
+    """hops=0 (no trusted proxy) must ignore XFF entirely and use socket IP."""
+    scope = {
+        "client": ("198.51.100.50", 5000),
+        "headers": [(b"x-forwarded-for", b"1.1.1.1")],
+    }
+    assert client_ip_from_scope(scope, trusted_proxy_hops=0) == "198.51.100.50"
+
+
+def test_client_ip_from_scope_no_xff_falls_back_to_socket():
+    scope = {"client": ("198.51.100.77", 5000), "headers": []}
+    assert client_ip_from_scope(scope, trusted_proxy_hops=1) == "198.51.100.77"
+
+
+# ───────────────────────────── config ───────────────────────────────────
+
+
+def test_config_defaults_when_absent():
+    cfg = RateLimitConfig(None)
+    assert cfg.enabled is True
+    assert cfg.trusted_proxy_hops == 1
+    # default tier always present; llm prefix tighter than search prefix
+    name_llm, _ = cfg.limits_for("/search/llm/events")
+    name_search, _ = cfg.limits_for("/search/prefix")
+    name_other, _ = cfg.limits_for("/taxonomy/tree")
+    assert name_llm == "/search/llm/"
+    assert name_search == "/search/"
+    assert name_other == "default"
+
+
+def test_config_can_disable():
+    assert RateLimitConfig({"enabled": False}).enabled is False
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -187,6 +187,39 @@ def test_spoofed_leftmost_xff_is_ignored():
     assert r2.status_code == 429  # same real client -> still limited
 
 
+def test_xff_ignored_when_socket_peer_is_public():
+    """A direct internet client (public socket peer) must not be able to
+    spoof X-Forwarded-For — its own socket IP is the key. This closes the
+    bucket-rotation bypass if the app port is ever exposed without a proxy."""
+    scope = {
+        "client": ("203.0.113.200", 5000),  # public peer = not our proxy
+        "headers": [(b"x-forwarded-for", b"1.1.1.1")],
+    }
+    assert client_ip_from_scope(scope, trusted_proxy_hops=1) == "203.0.113.200"
+
+
+def test_xff_trusted_when_socket_peer_is_private():
+    """Our reverse proxy connects from the docker network (private range)."""
+    scope = {
+        "client": ("172.18.0.5", 5000),  # docker bridge = plausible proxy
+        "headers": [(b"x-forwarded-for", b"spoofed, 198.51.100.9")],
+    }
+    assert client_ip_from_scope(scope, trusted_proxy_hops=1) == "198.51.100.9"
+
+
+def test_multiple_xff_header_lines_joined_in_order():
+    """A client-smuggled separate XFF line must not shadow the proxy-written
+    one: all lines are joined in wire order and the rightmost entry wins."""
+    scope = {
+        "client": ("172.18.0.5", 5000),
+        "headers": [
+            (b"x-forwarded-for", b"9.9.9.9"),  # client-sent forged line
+            (b"x-forwarded-for", b"198.51.100.9"),  # proxy-appended line
+        ],
+    }
+    assert client_ip_from_scope(scope, trusted_proxy_hops=1) == "198.51.100.9"
+
+
 def test_client_ip_from_scope_rightmost_with_one_hop():
     scope = {
         "client": ("172.17.0.1", 5000),
@@ -236,6 +269,35 @@ def test_config_defaults_when_absent():
 
 def test_config_can_disable():
     assert RateLimitConfig({"enabled": False}).enabled is False
+
+
+def test_config_rejects_empty_tier():
+    """An empty tier list would silently mean 'unlimited' — refuse it."""
+    with pytest.raises(ValueError):
+        RateLimitConfig({"tiers": {"/search/": [], "default": ["1/minute"]}})
+
+
+def test_exempt_prefix_respects_segment_boundary():
+    """/mcp exempts /mcp and /mcp/..., but NOT /mcp-evil (over-exemption)."""
+    cfg = RateLimitConfig(None)
+    assert cfg.is_exempt("/mcp") is True
+    assert cfg.is_exempt("/mcp/tools") is True
+    assert cfg.is_exempt("/mcp-evil") is False
+    assert cfg.is_exempt("/docs") is True
+    assert cfg.is_exempt("/docsomething") is False
+
+
+def test_header_pair_reports_same_tightest_limit():
+    """X-RateLimit-Limit and -Remaining must describe the SAME limit item:
+    with 3/minute + 100/hour, after one request the tightest is the minute
+    bucket (2 remaining) and the Limit header must name the minute limit."""
+    client = _make_client(
+        {"tiers": {"/search/": ["3/minute", "100/hour"], "default": ["100/minute"]}}
+    )
+    r = client.get("/search/prefix?query=x")
+    assert r.status_code == 200
+    assert r.headers["X-RateLimit-Remaining"] == "2"
+    assert "minute" in r.headers["X-RateLimit-Limit"]
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -530,6 +530,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "dill"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -584,6 +596,7 @@ dependencies = [
     { name = "folio-mcp" },
     { name = "folio-python", extra = ["search"] },
     { name = "jinja2" },
+    { name = "limits" },
     { name = "uvicorn" },
 ]
 
@@ -606,6 +619,7 @@ requires-dist = [
     { name = "folio-mcp", specifier = ">=0.2.0" },
     { name = "folio-python", extras = ["search"], specifier = ">=0.3.3" },
     { name = "jinja2", specifier = ">=3.1.6" },
+    { name = "limits", specifier = ">=3.13,<6" },
     { name = "uvicorn", specifier = ">=0.30.6" },
 ]
 
@@ -811,6 +825,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
+]
+
+[[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
 ]
 
 [[package]]
@@ -2119,4 +2147,90 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/8b/59781d0fe7b0adfbea37f600857de4be68921e454aeecf1a11bda35cdccc/wrapt-2.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:055e6fcfaa28e58c6a8c247d48b92be9d56f818b7068aa4f22b15b3343a09931", size = 80556, upload-time = "2026-06-20T23:47:28.473Z" },
+    { url = "https://files.pythonhosted.org/packages/94/dc/66c61aca927230c9cf97a3cb005c803971a1076ff9f7d61085d035c20085/wrapt-2.2.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8374eb6b1a58809211e84ff835a182bb17ab2807a5bfef23204c8cff38178a00", size = 81648, upload-time = "2026-06-20T23:47:30.504Z" },
+    { url = "https://files.pythonhosted.org/packages/23/1b/545eee1c18f3af4cf140bb5822b6ef81ebe569df0a63ac109973103a30a5/wrapt-2.2.2-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:656593bb3f5529f03d27af4136c4d7b11990e470bcbc6fefa5ef218695bece55", size = 152956, upload-time = "2026-06-20T23:47:31.867Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a7/6f42a3d03e44dc612a5dcff324e7366075a7857f0be2d49a8cb8a68279b8/wrapt-2.2.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dfb00cb7bb22099e2f64b7340fb96113639aa7260c0972af3797ace2297b936c", size = 154771, upload-time = "2026-06-20T23:47:33.352Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/55/4d76175aaa97523c38f1d28f79d18ab41a1b116814158a818bc0eba00571/wrapt-2.2.2-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e7f10ee0bd53673bfd52b67cbce83336fe6cad90d2377b03baf66491d2bbfb91", size = 149460, upload-time = "2026-06-20T23:47:34.712Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9b/12e23264d8f4735e8483262f95c5a6b03c3665fd2a84bdf99a45b6a2f4ec/wrapt-2.2.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4402f57c5f0d0579599858ffbdd9bf4e3f0972f51096f2bd6cc7dab6b76ee49e", size = 153648, upload-time = "2026-06-20T23:47:36.092Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/a3/bcd5ec37289dcd85ecd4d15395a6a6063d60bc45ff94a9d77814e1e54d64/wrapt-2.2.2-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:3a4eb7964ff4643d333c84f880bcf554652b2a1050aebc54ae696327f61acfaf", size = 148502, upload-time = "2026-06-20T23:47:37.623Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/be/716d708f607fa70f8a6eb47dff8ee945d5278dfc89ffeeff33039d052e63/wrapt-2.2.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e542b7c5af91e2123a8aabf19894319d5ec4268d2a9ffd2f239386133fc47746", size = 152238, upload-time = "2026-06-20T23:47:39.118Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/c0/1a48e7e54501274f5d906f18372221b13183b0afbb5b8bb4c7ca0392c0b4/wrapt-2.2.2-cp310-cp310-win32.whl", hash = "sha256:6e7e45b43d3c774d244fe7264378f5a3f0f383bc55a54a9866434e524540110f", size = 77278, upload-time = "2026-06-20T23:47:40.476Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/82/9cd69a1af288fbdedf01a10e3c8a0b6890b08c7f3f96d36a213699dbcd94/wrapt-2.2.2-cp310-cp310-win_amd64.whl", hash = "sha256:955f1d6e72a352e478de8d8b503abe301c5e139a141b62eb0923bd694995025f", size = 80131, upload-time = "2026-06-20T23:47:41.785Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/73/8db7e27daef37ae70a53ea62bef7fe80cc51a8b5e9e9181a8be6eb9a999c/wrapt-2.2.2-cp310-cp310-win_arm64.whl", hash = "sha256:b89d8d73c82db2bb7e6090b3afd7973f980d24e905cc34394eab60b884b3bf67", size = 79615, upload-time = "2026-06-20T23:47:43.109Z" },
+    { url = "https://files.pythonhosted.org/packages/27/15/0c2d55168707465abfc41f33c0b23d792a5fa9b65c26983606940900a120/wrapt-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f1a2ff355ece6a111ca7a20dc86df6659c9205d3fcee674ca34f2a2854fd4e73", size = 80782, upload-time = "2026-06-20T23:47:44.367Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b5/5c0b093eb48f8a062ef6267d3cb36e9bb1b88440181f6545a383c60efdf8/wrapt-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55b9a899e6fff5444f229d30aa6e9ac92d2216d9d60f33c771b5d76a760d5f8e", size = 81678, upload-time = "2026-06-20T23:47:45.857Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f3/de70937472dd3e8a4e6811192f9c6075efdffd4a2cd9b4596bf160f89668/wrapt-2.2.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a2d78c363f97d8bd718ee40432c66395685e9e98528ccaa423c3355d1715a26d", size = 159671, upload-time = "2026-06-20T23:47:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/40aed2330e7f02ecf74386ffcfef9ccb7108c6a430f15b6a252b663b1bed/wrapt-2.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d619e1eed9bd4f6ed9f24cd61971aa086fa86505289628d464bcf8a2c2e3f328", size = 160785, upload-time = "2026-06-20T23:47:48.759Z" },
+    { url = "https://files.pythonhosted.org/packages/45/04/aa5309beed5344b00220ae6b3b24055852192656194c27947bee1736306a/wrapt-2.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:518b0c5e323511ec56a38894802ddd5e1222626484e68efe63f201854ad788e5", size = 153699, upload-time = "2026-06-20T23:47:50.177Z" },
+    { url = "https://files.pythonhosted.org/packages/01/df/2def7e99d1fe87eea413f95f671924cdddcb08823b1ffd212748dfa6d062/wrapt-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4bccea5cdecffa9dd70e343741f0e41e0a16619313d04b72f78bb525162ebcd0", size = 159695, upload-time = "2026-06-20T23:47:51.602Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f6/a906d01a2ce12157bad2404957b3e2140da354b8a70b2fa48bbf282871c0/wrapt-2.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:209112cafd963710a05d199aae431d79a28bc76eb8e6d1bbbb8ad24340722cae", size = 152813, upload-time = "2026-06-20T23:47:53.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/49/bc0086292d239575b4c08f4cf8a4079fa58abbad58ec23abf84833a283ed/wrapt-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5a5290e4bf2f332fc29ce72ffb9a2fff678aaac047e2e9f5f7165cd7792e099", size = 158809, upload-time = "2026-06-20T23:47:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/55/83/8fbd034de1f3e907edaa18786d5dd8f6932874edee0826c7cecb5cab03a1/wrapt-2.2.2-cp311-cp311-win32.whl", hash = "sha256:5499236ad1dc116012e2a5dd943f3f31af12fce452128e2bbcbd55a7d3d4d14c", size = 77414, upload-time = "2026-06-20T23:47:55.882Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/9c/23695baa331c6de4e874c3d78b8e0bed92e1d2a274e665b29858f6841672/wrapt-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8636809939152be6ae20a6cef0fed9fe60f411b47847d0426a826884b469e971", size = 80368, upload-time = "2026-06-20T23:47:57.237Z" },
+    { url = "https://files.pythonhosted.org/packages/08/49/40cefc342bf89b234a4490d741290fce781774b831aefb39c25471da96c9/wrapt-2.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:5d0a142f7af07caeb5e5da87493162a7b8efa19ba919e550a746f7446e13fb30", size = 79489, upload-time = "2026-06-20T23:47:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]


### PR DESCRIPTION
## Problem

PR #19 (already live on prod) dropped the Caddy `rate_limit @api 100r/m` directive from the prod Caddyfile — it required a Caddy plugin absent from stock `caddy:latest` that was breaking `docker compose up`. Since then **prod has had zero rate limiting** on `/search/*`, **including the paid `/search/llm/*` routes** that make real OpenAI/XAI calls per request: an unauthenticated cost-DoS vector, flagged HIGH by review on 2026-07-07.

## Fix — app-level, portable

Rate limiting is restored **inside the app** (new `folio_api/rate_limit.py`), not re-added to Caddy, so the protection travels with the code across every deploy target we run (Caddy on bare-metal prod, Traefik/Coolify on dev, Railway, plain `docker run`):

- **Pure-ASGI middleware** over the [`limits`](https://github.com/alisaifee/limits) library (the same engine slowapi/flask-limiter wrap). Pure-ASGI so the mounted `/mcp` SSE app streams through untouched; centralized tier config instead of decorating ~20 LLM routes one-by-one.
- **Tiers by path prefix** (longest match wins), configurable via `api.rate_limit` in `config.json`, protective defaults baked into code if the block is absent:

  | Tier | Limit | Rationale |
  |---|---|---|
  | `/search/llm/` | 10/minute + 100/hour | paid LLM calls — tightest |
  | `/search/` | 60/minute + 1000/hour | non-LLM search — moderate |
  | default | 240/minute | everything else — generous |

  Health (`/info/health`), `/static`, docs, and `/mcp` are exempt (MCP exposes no `search_by_llm` tools — verified not a paid bypass).
- **Keyed by client IP, proxy-aware:** behind one trusted reverse proxy the real client is the **rightmost** `X-Forwarded-For` entry (the proxy appends the socket peer it saw, so a client-spoofed leftmost value can't rotate to evade limits). `trusted_proxy_hops` is configurable; `0` = trust only the socket peer.
- **429 + `Retry-After`** + `X-RateLimit-*` headers on rejection; allowed responses carry `X-RateLimit-Remaining`. CORS stays outermost so 429s are readable cross-origin.
- **Scaling:** `memory://` storage is correct for the single-worker uvicorn deploy; `storage_uri: redis://…` supported for multi-worker/replica.

## Dependency

`limits>=3.13,<6` (MIT, pinned 5.8.0 in `uv.lock`) — logged in `THIRD-PARTY.md` with rationale for depending on it directly rather than via slowapi.

## Tests

15 new tests in `tests/test_rate_limit.py` (per-route tiers, most-specific-prefix wins, 429/Retry-After/X-RateLimit headers, XFF spoof-resistance, `trusted_proxy_hops` 0/1/2, exemptions, config defaults/disable). Full suite: **31 passed**.

## Review

- Security review: no blocking issues (XFF rightmost spoof-resistant for the deployed topology; `/search/llm/*` coverage confirmed; MemoryStorage self-evicting; no injection/info-leak in 429).
- README + THIRD-PARTY deltas included; stale "Caddy provides rate limiting" README claim corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELAutiUDrKdGf2vZAwgt9Q