### PR TITLE
Fix MCP mount so the streamable HTTP endpoint actually works

### DIFF
--- a/folio_api/api.py
+++ b/folio_api/api.py
@@ -6,7 +6,7 @@ import logging
 import logging.config
 import os
 from collections import defaultdict
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
 from typing import Any, Dict
 from pathlib import Path
 
@@ -102,7 +102,15 @@ async def lifespan_handler(app_instance: FastAPI):
         "FOLIO instance initialized with llm %s", app_instance.state.folio.llm.model
     )
 
-    yield
+    # The MCP server is mounted as a sub-application (see get_app()), but Starlette
+    # does not forward ASGI lifespan events to mounted sub-apps. Its streamable-HTTP
+    # session manager needs its own lifespan entered explicitly here, or every
+    # request 500s with "Task group is not initialized."
+    mcp_app = app_instance.state.mcp_app
+    async with AsyncExitStack() as mcp_stack:
+        await mcp_stack.enter_async_context(mcp_app.router.lifespan_context(mcp_app))
+
+        yield
 
     # log shutdown
     app_instance.state.logger.info("Shutting down API")
@@ -277,10 +285,20 @@ def get_app() -> FastAPI:
     # root.router has /{iri} catch-all, so it must be registered last
     app_instance.include_router(folio_api.routes.root.router)
 
-    # Mount FOLIO MCP server at /mcp
+    # Mount the FOLIO MCP server at the app root, relying on its own default
+    # streamable_http_path ("/mcp") to define the live endpoint. Mounting the
+    # sub-app AT "/mcp" instead (i.e. Mount("/mcp", mcp_app) with the default
+    # inner path) would nest it at "/mcp/mcp", and even correcting the inner
+    # path to "/" would still require a trailing slash on every request
+    # (Starlette's Mount regex is "<path>/{path:path}", which never matches
+    # the bare mount path with nothing after it). Stash the sub-app on state
+    # so lifespan_handler can enter its session-manager lifespan (Starlette
+    # does not cascade ASGI lifespan events into mounted sub-apps).
     from folio_mcp.server import mcp as folio_mcp_server
 
-    app_instance.mount("/mcp", folio_mcp_server.streamable_http_app())
+    mcp_app = folio_mcp_server.streamable_http_app()
+    app_instance.state.mcp_app = mcp_app
+    app_instance.mount("/", mcp_app)
 
     return app_instance
 


### PR DESCRIPTION
## Problem

The FOLIO MCP server mounted in `folio_api/api.py` doesn't work — every request to `/mcp` either 405s or, if it reaches the sub-app at all, 500s.

## Root cause (two separate bugs)

**1. Double-mounted path.** The MCP sub-app is mounted at `/mcp`:
```python
app_instance.mount("/mcp", folio_mcp_server.streamable_http_app())
```
`streamable_http_app()`'s own default `streamable_http_path` is *also* `/mcp`, so the sub-app expects requests at `/mcp` relative to its own mount root — making the real live endpoint `/mcp/mcp`, not `/mcp`. A bare `POST /mcp` falls through to the `/{iri}` catch-all route in `root.router` (GET-only), returning 405.

This can't be fixed by keeping the outer mount at `/mcp` and overriding the inner path to `/`, either — Starlette's `Mount` always compiles its path regex as `"<path>/{path:path}"`, which requires a literal trailing `/` after any non-root mount path. That makes `/mcp/` work but the bare `/mcp` (no trailing slash) permanently unmatchable via that mount, no matter what the inner path is set to.

The fix is to mount the sub-app at the **app root** and let its own default `streamable_http_path="/mcp"` define the live path — the pattern the MCP SDK's own examples use. That produces an exact match on `/mcp` with no trailing slash required.

**2. Session manager lifespan never starts.** Even with routing fixed, every request 500s with:
```
RuntimeError: Task group is not initialized. Make sure to use run().
```
`streamable_http_app()` returns a Starlette app whose `lifespan` is `lambda app: session_manager.run()` — but Starlette does not forward ASGI lifespan events into *mounted* sub-apps. Since `folio_api`'s own `lifespan_handler` never entered that sub-app's lifespan, the `StreamableHTTPSessionManager`'s task group was never started.

Fixed by stashing the mounted sub-app on `app_instance.state` and entering its `router.lifespan_context(...)` from `lifespan_handler` via an `AsyncExitStack`.

## Testing

Verified locally against a running container:
- `POST /mcp` (bare, no trailing slash) → 200, full `initialize` handshake with FOLIO's tool/prompt list
- Existing routes unaffected: `GET /info/health`, `GET /docs`, `GET /openapi.json` all still 200

## Related

This repo currently depends on `folio-mcp>=0.2.0` from PyPI, which still targets the retired `mcp.server.fastmcp` import path. This fix was tested against the SDK-v2-compatible `folio-mcp` checkout from #2 (**[Migrate to mcp Python SDK v2](https://github.com/alea-institute/folio-mcp/pull/2)**), and should be merged alongside — or after — that PR lands and a new `folio-mcp` release ships.